### PR TITLE
Use dataclass for reference marks

### DIFF
--- a/layerforge/models/reference_marks/__init__.py
+++ b/layerforge/models/reference_marks/__init__.py
@@ -1,3 +1,4 @@
+from .reference_mark import ReferenceMark
 from .reference_mark_adjuster import ReferenceMarkAdjuster
 from .reference_mark_calculator import ReferenceMarkCalculator
 from .reference_mark_manager import ReferenceMarkManager

--- a/layerforge/models/reference_marks/reference_mark.py
+++ b/layerforge/models/reference_marks/reference_mark.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+@dataclass
+class ReferenceMark:
+    """Represents a reference mark on a slice."""
+
+    x: float
+    y: float
+    shape: str
+    size: float

--- a/layerforge/models/reference_marks/reference_mark_adjuster.py
+++ b/layerforge/models/reference_marks/reference_mark_adjuster.py
@@ -1,48 +1,33 @@
-from typing import List, Tuple
+from typing import List
 
 from shapely.geometry import Point, Polygon
 
+from .reference_mark import ReferenceMark
+
 
 class ReferenceMarkAdjuster:
-    """Adjust the reference marks to avoid overlapping with the contours."""
+    """Adjust reference marks so they don't conflict with slice contours."""
 
     @staticmethod
     def adjust_marks(
-        marks: List[Tuple[float, float, str, float]],
+        marks: List[ReferenceMark],
         contours: List[Polygon],
         min_distance: float = 10.0,
-    ) -> List[Tuple[float, float, str, float]]:
-        """Adjust the reference marks to avoid overlapping with the contours.
-
-        Parameters
-        ----------
-        marks : List[Tuple[float, float, str, float]]
-            A list of reference marks represented as tuples ``(x, y, shape, size)``.
-        contours : List[Polygon]
-            A list of polygons to avoid overlapping with.
-        min_distance : float, optional
-            The minimum distance between marks and contours.
-
-        Returns
-        -------
-        List[Tuple[float, float, str, float]]
-            The adjusted reference marks.
-        """
-        adjusted_marks = []
+    ) -> List[ReferenceMark]:
+        """Return a filtered list of ``marks`` respecting ``min_distance``."""
+        adjusted_marks: List[ReferenceMark] = []
         for mark in marks:
-            mark_point = Point(mark[0], mark[1])
-            is_too_close = False
-            for model_polygon in contours:
-                if model_polygon.boundary.distance(mark_point) < min_distance:
-                    is_too_close = True
-                    break
-            if not is_too_close:
-                is_overlapping = False
-                for adj_mark in adjusted_marks:
-                    adj_mark_point = Point(adj_mark[0], adj_mark[1])
-                    if mark_point.distance(adj_mark_point) < min_distance:
-                        is_overlapping = True
-                        break
-                if not is_overlapping:
-                    adjusted_marks.append(mark)
+            mark_point = Point(mark.x, mark.y)
+            is_too_close = any(
+                polygon.boundary.distance(mark_point) < min_distance
+                for polygon in contours
+            )
+            if is_too_close:
+                continue
+            is_overlapping = any(
+                mark_point.distance(Point(adj_mark.x, adj_mark.y)) < min_distance
+                for adj_mark in adjusted_marks
+            )
+            if not is_overlapping:
+                adjusted_marks.append(mark)
         return adjusted_marks

--- a/layerforge/models/reference_marks/reference_mark_manager.py
+++ b/layerforge/models/reference_marks/reference_mark_manager.py
@@ -1,64 +1,34 @@
+from typing import List, Optional
+
 from layerforge.utils import calculate_distance
+from .reference_mark import ReferenceMark
 
 
 class ReferenceMarkManager:
-    """Manages reference marks on a slice of a 3D model.
+    """Manage reference marks on a slice of a 3D model.
 
     Attributes
     ----------
-    marks : list
-        A list of reference marks. Each mark is a dict with keys: x, y, shape, size
+    marks : List[ReferenceMark]
+        Collected reference marks for the model.
     """
 
-    def __init__(self):
-        self.marks = []
+    def __init__(self) -> None:
+        self.marks: List[ReferenceMark] = []
 
-    def find_mark_by_position(self, x: float, y: float, tolerance: float = 10) -> dict or None:
-        """Accept a mark by its position if within tolerance.
-
-        Parameters
-        ----------
-        x : float
-            The x-coordinate of the mark.
-        y : float
-            The y-coordinate of the mark.
-        tolerance : float, optional
-            The maximum distance between the mark and the given position.
-
-        Returns
-        -------
-        dict or None
-            The mark if found within tolerance, otherwise None.
-        """
+    def find_mark_by_position(self, x: float, y: float, tolerance: float = 10) -> Optional[ReferenceMark]:
+        """Return the mark at ``(x, y)`` if within ``tolerance`` distance."""
         for mark in self.marks:
-            distance = calculate_distance(mark['x'], mark['y'], x, y)
+            distance = calculate_distance(mark.x, mark.y, x, y)
             if distance <= tolerance:
                 return mark
         return None
 
     def add_or_update_mark(self, x: float, y: float, shape: str, size: float) -> None:
-        """Add or update a reference mark at the given position.
-
-        The mark is updated if it already exists within tolerance.
-
-        Parameters
-        ----------
-        x : float
-            The x-coordinate of the mark.
-        y : float
-            The y-coordinate of the mark.
-        shape : str
-            The shape of the mark.
-        size : float
-            The size of the mark.
-
-        Returns
-        -------
-        None
-        """
+        """Add a new mark or update an existing one."""
         mark = self.find_mark_by_position(x, y)
         if mark:
-            mark['shape'] = shape
-            mark['size'] = size
+            mark.shape = shape
+            mark.size = size
         else:
-            self.marks.append({'x': x, 'y': y, 'shape': shape, 'size': size})
+            self.marks.append(ReferenceMark(x=x, y=y, shape=shape, size=size))

--- a/layerforge/models/slicing/slice.py
+++ b/layerforge/models/slicing/slice.py
@@ -3,9 +3,12 @@ from typing import List
 
 from shapely.geometry import Polygon
 
-from layerforge.models.reference_marks import ReferenceMarkAdjuster
-from layerforge.models.reference_marks import ReferenceMarkCalculator
-from layerforge.models.reference_marks import ReferenceMarkManager
+from layerforge.models.reference_marks import (
+    ReferenceMark,
+    ReferenceMarkAdjuster,
+    ReferenceMarkCalculator,
+    ReferenceMarkManager,
+)
 from layerforge.utils import calculate_distance
 
 
@@ -22,7 +25,7 @@ class Slice:
         A list of contours in the slice.
     origin : tuple
         The origin of the model.
-    ref_marks : list
+    ref_marks : List[ReferenceMark]
         A list of reference marks in the slice.
     mark_manager : ReferenceMarkManager
         The reference mark manager for the slice.
@@ -51,7 +54,7 @@ class Slice:
         self.origin = origin
         self.position = position
 
-        self.ref_marks = []
+        self.ref_marks: List[ReferenceMark] = []
 
     def process_reference_marks(self) -> None:
         """Process reference marks for the slice.
@@ -69,12 +72,14 @@ class Slice:
             x, y = centroid
             existing_mark = self.mark_manager.find_mark_by_position(x, y)
             if existing_mark:
-                self.ref_marks.append((x, y, existing_mark['shape'], existing_mark['size']))
+                self.ref_marks.append(
+                    ReferenceMark(x=x, y=y, shape=existing_mark.shape, size=existing_mark.size)
+                )
             else:
                 new_shape = self._select_unique_shape()
                 new_size = self._calculate_mark_size(x, y)
                 self.mark_manager.add_or_update_mark(x, y, new_shape, new_size)
-                self.ref_marks.append((x, y, new_shape, new_size))
+                self.ref_marks.append(ReferenceMark(x=x, y=y, shape=new_shape, size=new_size))
 
     def adjust_marks(self) -> None:
         """Adjust reference marks for the slice.
@@ -106,7 +111,7 @@ class Slice:
             A unique shape for the reference mark.
         """
         available_shapes = ['circle', 'square', 'triangle', 'arrow']
-        used_shapes = {mark['shape'] for mark in self.mark_manager.marks}
+        used_shapes = {mark.shape for mark in self.mark_manager.marks}
         for shape in available_shapes:
             if shape not in used_shapes:
                 return shape

--- a/tests/test_reference_mark_adjuster.py
+++ b/tests/test_reference_mark_adjuster.py
@@ -2,21 +2,33 @@ import pytest
 from shapely.geometry import Polygon
 
 import importlib.util
+import sys
+import types
 from pathlib import Path
 
+ROOT = Path(__file__).resolve().parents[1]
+module_name = "layerforge.models.reference_marks.reference_mark_adjuster"
 spec = importlib.util.spec_from_file_location(
-    "reference_mark_adjuster",
-    Path(__file__).resolve().parents[1]
-    / "layerforge/models/reference_marks/reference_mark_adjuster.py",
+    module_name, ROOT / "layerforge/models/reference_marks/reference_mark_adjuster.py"
 )
-adjuster = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(adjuster)  # type: ignore
-ReferenceMarkAdjuster = adjuster.ReferenceMarkAdjuster
+module = importlib.util.module_from_spec(spec)
+
+pkg_layerforge = types.ModuleType("layerforge")
+pkg_models = types.ModuleType("layerforge.models")
+pkg_ref = types.ModuleType("layerforge.models.reference_marks")
+pkg_ref.__path__ = [str(ROOT / "layerforge/models/reference_marks")]
+sys.modules.setdefault("layerforge", pkg_layerforge)
+sys.modules.setdefault("layerforge.models", pkg_models)
+sys.modules.setdefault("layerforge.models.reference_marks", pkg_ref)
+sys.modules[module_name] = module
+spec.loader.exec_module(module)  # type: ignore
+ReferenceMarkAdjuster = module.ReferenceMarkAdjuster
+ReferenceMark = module.ReferenceMark
 
 
 def test_centroid_inside_kept():
     square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
-    marks = [(50, 50, 'circle', 3)]
+    marks = [ReferenceMark(50, 50, 'circle', 3)]
     adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], min_distance=10)
     assert adjusted == marks
 
@@ -24,9 +36,9 @@ def test_centroid_inside_kept():
 def test_marks_near_boundary_removed():
     square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
     marks = [
-        (5, 5, 'circle', 3),    # inside but near boundary
-        (105, 50, 'square', 3), # outside near boundary
-        (95, 95, 'circle', 3),  # inside near boundary
+        ReferenceMark(5, 5, 'circle', 3),    # inside but near boundary
+        ReferenceMark(105, 50, 'square', 3), # outside near boundary
+        ReferenceMark(95, 95, 'circle', 3),  # inside near boundary
     ]
     adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], min_distance=10)
     assert adjusted == []


### PR DESCRIPTION
## Summary
- introduce `ReferenceMark` dataclass
- refactor slice and reference mark helpers to use the dataclass
- update tests for new dataclass usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684720cf7f408333ad53341c98b9ff6b