### PR TITLE
Add configurable reference mark options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ A 3D Model Slicing and SVG Generation Application
 
 ## Configuration
 
+The CLI exposes parameters for tuning reference mark generation:
+
+- `--mark-tolerance` – distance used when matching an existing mark. Defaults to `10.0`.
+- `--mark-min-distance` – minimum distance from contours and between marks. Defaults to `10.0`.
+- `--available-shapes` – comma separated list of shapes to cycle through when creating marks. Defaults to `circle,square,triangle,arrow`.
+
 ## Contributing
 
 ## License

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,1 +1,11 @@
 # Configuration
+
+## Reference Mark Options
+
+The behaviour of reference mark generation can be tuned via the following configuration options or equivalent CLI arguments:
+
+- `tolerance` – distance used when matching an existing mark.
+- `min_distance` – minimum distance a mark must maintain from contours and other marks.
+- `available_shapes` – list of shapes that will be cycled through when creating new marks.
+
+These correspond to the CLI flags `--mark-tolerance`, `--mark-min-distance` and `--available-shapes` respectively.

--- a/layerforge/cli.py
+++ b/layerforge/cli.py
@@ -3,6 +3,7 @@ import sys
 import click
 
 from layerforge.models import Model, ModelFactory, SlicerService
+from layerforge.models.reference_marks import ReferenceMarkConfig
 from layerforge.models.loading import LoaderFactory
 from layerforge.svg import SVGGenerator
 from layerforge.svg.drawing import StrategyContext
@@ -10,7 +11,12 @@ from layerforge.utils import initialize_loaders, register_shape_strategies
 from layerforge.writers import SVGFileWriter
 
 
-def process_model(model: Model, output_folder: str, shape_context: StrategyContext) -> None:
+def process_model(
+    model: Model,
+    output_folder: str,
+    shape_context: StrategyContext,
+    config: ReferenceMarkConfig,
+) -> None:
     """Process the model and generate SVG slices.
 
     Parameters
@@ -27,7 +33,7 @@ def process_model(model: Model, output_folder: str, shape_context: StrategyConte
     None
     """
     # TODO: Refactor this to either include the rest of the logic that is in the CLI function, or completely rewrite it.
-    slices = SlicerService.slice_model(model)
+    slices = SlicerService.slice_model(model, config=config)
     svg_writer = SVGFileWriter()
     svg_generator = SVGGenerator(output_folder, svg_writer, shape_context)
     svg_generator.generate_svgs(slices)
@@ -39,7 +45,19 @@ def process_model(model: Model, output_folder: str, shape_context: StrategyConte
 @click.option('--output-folder', default='output', help='The output folder for SVG files.')
 @click.option('--scale-factor', default=None, type=float, help='The scale factor to apply to the model.')
 @click.option('--target-height', default=None, type=float, help='The target height for the model.')
-def cli(stl_file: str, layer_height: float, output_folder: str, scale_factor: float, target_height: float) -> None:
+@click.option('--mark-tolerance', default=10.0, type=float, help='Tolerance when matching existing marks.')
+@click.option('--mark-min-distance', default=10.0, type=float, help='Minimum distance from contours and between marks.')
+@click.option('--available-shapes', default='circle,square,triangle,arrow', help='Comma separated list of mark shapes.')
+def cli(
+    stl_file: str,
+    layer_height: float,
+    output_folder: str,
+    scale_factor: float,
+    target_height: float,
+    mark_tolerance: float,
+    mark_min_distance: float,
+    available_shapes: str,
+) -> None:
     """Entry point for the CLI.
 
     This function wraps all the logic for processing an STL file and
@@ -73,7 +91,13 @@ def cli(stl_file: str, layer_height: float, output_folder: str, scale_factor: fl
     model_factory = ModelFactory(mesh_loader)
     model = model_factory.create_model(stl_file, layer_height, scale_factor, target_height)
 
-    process_model(model, output_folder, shape_context)
+    config = ReferenceMarkConfig(
+        tolerance=mark_tolerance,
+        min_distance=mark_min_distance,
+        available_shapes=[s.strip() for s in available_shapes.split(',') if s.strip()],
+    )
+
+    process_model(model, output_folder, shape_context, config)
 
 
 if __name__ == '__main__':

--- a/layerforge/models/reference_marks/__init__.py
+++ b/layerforge/models/reference_marks/__init__.py
@@ -2,3 +2,4 @@ from .reference_mark import ReferenceMark
 from .reference_mark_adjuster import ReferenceMarkAdjuster
 from .reference_mark_calculator import ReferenceMarkCalculator
 from .reference_mark_manager import ReferenceMarkManager
+from .config import ReferenceMarkConfig

--- a/layerforge/models/reference_marks/config.py
+++ b/layerforge/models/reference_marks/config.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from typing import List
+
+@dataclass
+class ReferenceMarkConfig:
+    """Configuration options for reference marks."""
+
+    tolerance: float = 10.0
+    min_distance: float = 10.0
+    available_shapes: List[str] = field(
+        default_factory=lambda: ["circle", "square", "triangle", "arrow"]
+    )

--- a/layerforge/models/reference_marks/reference_mark_adjuster.py
+++ b/layerforge/models/reference_marks/reference_mark_adjuster.py
@@ -3,6 +3,7 @@ from typing import List
 from shapely.geometry import Point, Polygon
 
 from .reference_mark import ReferenceMark
+from .config import ReferenceMarkConfig
 
 
 class ReferenceMarkAdjuster:
@@ -12,9 +13,11 @@ class ReferenceMarkAdjuster:
     def adjust_marks(
         marks: List[ReferenceMark],
         contours: List[Polygon],
-        min_distance: float = 10.0,
+        config: ReferenceMarkConfig | None = None,
     ) -> List[ReferenceMark]:
-        """Return a filtered list of ``marks`` respecting ``min_distance``."""
+        """Return a filtered list of ``marks`` respecting ``config.min_distance``."""
+        cfg = config or ReferenceMarkConfig()
+        min_distance = cfg.min_distance
         adjusted_marks: List[ReferenceMark] = []
         for mark in marks:
             mark_point = Point(mark.x, mark.y)

--- a/layerforge/models/reference_marks/reference_mark_calculator.py
+++ b/layerforge/models/reference_marks/reference_mark_calculator.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, List, Tuple
 from shapely.geometry import Point, Polygon
 
 from layerforge.utils import calculate_distance
+from .config import ReferenceMarkConfig
 
 if TYPE_CHECKING:
     from layerforge.models.slicing.slice import Slice
@@ -46,9 +47,11 @@ class ReferenceMarkCalculator:
     def get_stable_marks(
         layer: Slice,
         existing_marks: List[Tuple[float, float]],
-        min_distance: float = 10.0,
+        config: ReferenceMarkConfig | None = None,
     ) -> List[Tuple[float, float]]:
-        """Return stable mark positions for ``layer``."""
+        """Return stable mark positions for ``layer`` respecting ``config.min_distance``."""
+        cfg = config or ReferenceMarkConfig()
+        min_distance = cfg.min_distance
         selected: List[Tuple[float, float]] = []
         for poly in layer.contours:
             # Try to inherit an existing mark that is inside the polygon

--- a/layerforge/models/reference_marks/reference_mark_manager.py
+++ b/layerforge/models/reference_marks/reference_mark_manager.py
@@ -2,6 +2,8 @@ from typing import List, Optional
 
 from shapely.geometry import Point, Polygon
 
+from .config import ReferenceMarkConfig
+
 from layerforge.utils import calculate_distance
 from .reference_mark import ReferenceMark
 
@@ -15,11 +17,14 @@ class ReferenceMarkManager:
         Collected reference marks for the model.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, config: ReferenceMarkConfig | None = None) -> None:
         self.marks: List[ReferenceMark] = []
+        self.config = config or ReferenceMarkConfig()
 
-    def find_mark_by_position(self, x: float, y: float, tolerance: float = 10) -> Optional[ReferenceMark]:
+    def find_mark_by_position(self, x: float, y: float, tolerance: float | None = None) -> Optional[ReferenceMark]:
         """Return the mark at ``(x, y)`` if within ``tolerance`` distance."""
+        if tolerance is None:
+            tolerance = self.config.tolerance
         for mark in self.marks:
             distance = calculate_distance(mark.x, mark.y, x, y)
             if distance <= tolerance:
@@ -35,8 +40,10 @@ class ReferenceMarkManager:
         else:
             self.marks.append(ReferenceMark(x=x, y=y, shape=shape, size=size))
 
-    def find_mark_in_polygon(self, polygon: Polygon, min_distance: float = 10.0) -> Optional[ReferenceMark]:
+    def find_mark_in_polygon(self, polygon: Polygon, min_distance: float | None = None) -> Optional[ReferenceMark]:
         """Return a stored mark inside ``polygon`` respecting ``min_distance``."""
+        if min_distance is None:
+            min_distance = self.config.min_distance
         for mark in self.marks:
             pt = Point(mark.x, mark.y)
             if polygon.contains(pt) and polygon.boundary.distance(pt) >= min_distance:

--- a/layerforge/models/slicing/slicer_service.py
+++ b/layerforge/models/slicing/slicer_service.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from layerforge.models import Slice, Model
-from layerforge.models.reference_marks import ReferenceMarkManager
+from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig
 
 
 class SlicerService:
@@ -25,7 +25,9 @@ class SlicerService:
         return [i * layer_height for i in range(int(total_height / layer_height) + 1)]
 
     @staticmethod
-    def slice_model(model: Model) -> List[Slice]:
+    def slice_model(
+        model: Model, config: ReferenceMarkConfig | None = None
+    ) -> List[Slice]:
         """Slice the model into layers
 
         Parameters
@@ -38,13 +40,22 @@ class SlicerService:
         List[Slice]
             A list of the slices
         """
-        slice_positions = SlicerService.calculate_slice_positions(model.calculate_height(), model.layer_height)
+        cfg = config or ReferenceMarkConfig()
+        slice_positions = SlicerService.calculate_slice_positions(
+            model.calculate_height(), model.layer_height
+        )
         slices = []
-        mark_manager = ReferenceMarkManager()
+        mark_manager = ReferenceMarkManager(config=cfg)
         for index, position in enumerate(slice_positions):
             contours = model.calculate_slice_contours(position)
-            slice_ = Slice(index=index, position=position, contours=contours, origin=model.origin,
-                           mark_manager=mark_manager)
+            slice_ = Slice(
+                index=index,
+                position=position,
+                contours=contours,
+                origin=model.origin,
+                mark_manager=mark_manager,
+                config=cfg,
+            )
             # TODO: Investigate if this is the best place to process the reference marks
             slice_.process_reference_marks()
             slice_.adjust_marks()

--- a/tests/test_reference_mark_adjuster.py
+++ b/tests/test_reference_mark_adjuster.py
@@ -25,11 +25,21 @@ spec.loader.exec_module(module)  # type: ignore
 ReferenceMarkAdjuster = module.ReferenceMarkAdjuster
 ReferenceMark = module.ReferenceMark
 
+module_name_config = "layerforge.models.reference_marks.config"
+spec_config = importlib.util.spec_from_file_location(
+    module_name_config, ROOT / "layerforge/models/reference_marks/config.py"
+)
+module_config = importlib.util.module_from_spec(spec_config)
+sys.modules[module_name_config] = module_config
+spec_config.loader.exec_module(module_config)  # type: ignore
+ReferenceMarkConfig = module_config.ReferenceMarkConfig
+
 
 def test_centroid_inside_kept():
     square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
     marks = [ReferenceMark(50, 50, 'circle', 3)]
-    adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], min_distance=10)
+    config = ReferenceMarkConfig(min_distance=10)
+    adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], config=config)
     assert adjusted == marks
 
 
@@ -40,5 +50,6 @@ def test_marks_near_boundary_removed():
         ReferenceMark(105, 50, 'square', 3), # outside near boundary
         ReferenceMark(95, 95, 'circle', 3),  # inside near boundary
     ]
-    adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], min_distance=10)
+    config = ReferenceMarkConfig(min_distance=10)
+    adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], config=config)
     assert adjusted == []

--- a/tests/test_reference_mark_calculator.py
+++ b/tests/test_reference_mark_calculator.py
@@ -42,6 +42,17 @@ pkg_ref.ReferenceMarkManager = None
 pkg_ref.ReferenceMarkCalculator = None
 pkg_ref.ReferenceMark = None
 pkg_ref.ReferenceMarkAdjuster = None
+pkg_ref.ReferenceMarkConfig = None
+
+module_name_config = "layerforge.models.reference_marks.config"
+spec_config = importlib.util.spec_from_file_location(
+    module_name_config, ROOT / "layerforge/models/reference_marks/config.py"
+)
+module_config = importlib.util.module_from_spec(spec_config)
+sys.modules[module_name_config] = module_config
+spec_config.loader.exec_module(module_config)  # type: ignore
+ReferenceMarkConfig = module_config.ReferenceMarkConfig
+pkg_ref.ReferenceMarkConfig = ReferenceMarkConfig
 
 sys.modules[module_name_slice] = module_slice
 
@@ -93,7 +104,8 @@ def test_inherit_mark_within_polygon():
     square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
     manager = ReferenceMarkManager()
     manager.add_or_update_mark(50, 50, "circle", 3)
-    sl = Slice(0, 0.0, [square], origin=(0, 0), mark_manager=manager)
+    cfg = ReferenceMarkConfig(min_distance=10)
+    sl = Slice(0, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg)
     sl.process_reference_marks()
     assert len(sl.ref_marks) == 1
     assert sl.ref_marks[0].x == 50
@@ -103,7 +115,8 @@ def test_inherit_mark_within_polygon():
 def test_generate_mark_respects_boundary():
     square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
     manager = ReferenceMarkManager()
-    sl = Slice(1, 0.0, [square], origin=(0, 0), mark_manager=manager)
+    cfg = ReferenceMarkConfig(min_distance=10)
+    sl = Slice(1, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg)
     sl.process_reference_marks()
     assert len(sl.ref_marks) == 1
     pt = Point(sl.ref_marks[0].x, sl.ref_marks[0].y)


### PR DESCRIPTION
## Summary
- expose mark tolerance, minimum distance, and shapes as CLI options
- pass configuration through ReferenceMarkManager, Slice, and SlicerService
- adjust calculators and adjusters to honour configuration
- document options in README and configuration guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684774c620ec8333b30b203928ef093e