### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,22 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . pytest shapely
+      - name: Run tests
+        run: pytest -q

--- a/layerforge/models/reference_marks/reference_mark_calculator.py
+++ b/layerforge/models/reference_marks/reference_mark_calculator.py
@@ -89,3 +89,14 @@ class ReferenceMarkCalculator:
             if best_pt:
                 selected.append(best_pt)
         return selected
+
+    @staticmethod
+    def get_potential_marks(
+        layer: "Slice",
+        existing_marks: List[Tuple[float, float]],
+        config: ReferenceMarkConfig | None = None,
+    ) -> List[Tuple[float, float]]:
+        """Compatibility alias for :meth:`get_stable_marks`."""
+        return ReferenceMarkCalculator.get_stable_marks(
+            layer, existing_marks, config=config
+        )

--- a/tests/test_calculator_get_potential_marks.py
+++ b/tests/test_calculator_get_potential_marks.py
@@ -1,0 +1,37 @@
+import pytest
+from shapely.geometry import Polygon, Point
+
+from layerforge.models.reference_marks import (
+    ReferenceMarkCalculator,
+    ReferenceMarkManager,
+    ReferenceMarkConfig,
+)
+from layerforge.models.slicing.slice import Slice
+
+
+def create_slice(polygons, manager=None, cfg=None):
+    manager = manager or ReferenceMarkManager(config=cfg)
+    cfg = cfg or ReferenceMarkConfig()
+    return Slice(0, 0.0, polygons, origin=(0, 0), mark_manager=manager, config=cfg)
+
+
+def test_potential_marks_inside_polygon():
+    square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    cfg = ReferenceMarkConfig(min_distance=10)
+    sl = create_slice([square], cfg=cfg)
+
+    marks = ReferenceMarkCalculator.get_potential_marks(sl, [], config=cfg)
+    assert len(marks) == 1
+    x, y = marks[0]
+    pt = Point(x, y)
+    assert square.contains(pt)
+    assert square.boundary.distance(pt) >= cfg.min_distance
+
+
+def test_existing_mark_inherited():
+    square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    cfg = ReferenceMarkConfig(min_distance=10)
+    sl = create_slice([square], cfg=cfg)
+
+    marks = ReferenceMarkCalculator.get_potential_marks(sl, [(50, 50)], config=cfg)
+    assert marks == [(50, 50)]

--- a/tests/test_reference_mark_adjuster_extra.py
+++ b/tests/test_reference_mark_adjuster_extra.py
@@ -1,0 +1,28 @@
+from shapely.geometry import Polygon
+
+from layerforge.models.reference_marks import (
+    ReferenceMarkAdjuster,
+    ReferenceMarkConfig,
+    ReferenceMark,
+)
+
+
+def test_overlapping_marks_removed():
+    square = Polygon([(0, 0), (50, 0), (50, 50), (0, 50)])
+    marks = [
+        ReferenceMark(25, 25, "circle", 3),
+        ReferenceMark(27, 25, "square", 3),
+    ]
+    cfg = ReferenceMarkConfig(min_distance=5)
+    adjusted = ReferenceMarkAdjuster.adjust_marks(marks, [square], config=cfg)
+    assert len(adjusted) == 1
+    assert adjusted[0].x == 25 and adjusted[0].y == 25
+
+
+def test_mark_near_other_polygon_removed():
+    poly1 = Polygon([(0, 0), (50, 0), (50, 50), (0, 50)])
+    poly2 = Polygon([(50, 0), (100, 0), (100, 50), (50, 50)])
+    mark = ReferenceMark(45, 25, "circle", 3)
+    cfg = ReferenceMarkConfig(min_distance=10)
+    adjusted = ReferenceMarkAdjuster.adjust_marks([mark], [poly1, poly2], config=cfg)
+    assert adjusted == []

--- a/tests/test_reference_mark_manager.py
+++ b/tests/test_reference_mark_manager.py
@@ -1,0 +1,19 @@
+from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMark
+
+
+def test_add_and_update_mark():
+    manager = ReferenceMarkManager()
+    manager.add_or_update_mark(10, 20, "circle", 3)
+    assert len(manager.marks) == 1
+    assert manager.marks[0].shape == "circle"
+    assert manager.marks[0].size == 3
+
+    # update existing position
+    manager.add_or_update_mark(10, 20, "square", 5)
+    assert len(manager.marks) == 1
+    assert manager.marks[0].shape == "square"
+    assert manager.marks[0].size == 5
+
+    # add new mark at different position
+    manager.add_or_update_mark(30, 40, "triangle", 4)
+    assert len(manager.marks) == 2

--- a/tests/test_slice_process_reference_marks.py
+++ b/tests/test_slice_process_reference_marks.py
@@ -1,0 +1,17 @@
+from shapely.geometry import Polygon
+
+from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig
+from layerforge.models.slicing.slice import Slice
+
+
+def test_new_mark_added_to_manager():
+    square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    manager = ReferenceMarkManager()
+    cfg = ReferenceMarkConfig(min_distance=10)
+    sl = Slice(0, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg)
+    sl.process_reference_marks()
+    assert len(sl.ref_marks) == 1
+    # manager should now contain the new mark
+    assert len(manager.marks) == 1
+    assert manager.marks[0].x == sl.ref_marks[0].x
+    assert manager.marks[0].y == sl.ref_marks[0].y


### PR DESCRIPTION
## Summary
- add compatibility alias `get_potential_marks`
- create pytest suites for `ReferenceMarkCalculator`, `ReferenceMarkManager`, `ReferenceMarkAdjuster`, and `Slice`
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477a1b519c8333a08884e4545e990b