### PR TITLE
Fix slice count rounding

### DIFF
--- a/layerforge/models/slicing/slicer_service.py
+++ b/layerforge/models/slicing/slicer_service.py
@@ -1,4 +1,5 @@
 from typing import List
+import math
 
 from layerforge.models import Slice, Model
 from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig
@@ -22,7 +23,13 @@ class SlicerService:
         list
             A list of the positions of the slices
         """
-        return [i * layer_height for i in range(int(total_height / layer_height) + 1)]
+        num_slices = max(1, math.ceil(total_height / layer_height))
+        positions = [i * layer_height for i in range(num_slices)]
+        if not positions or positions[-1] < total_height:
+            positions.append(total_height)
+        else:
+            positions[-1] = total_height
+        return positions
 
     @staticmethod
     def slice_model(

--- a/tests/test_slicer_service.py
+++ b/tests/test_slicer_service.py
@@ -1,0 +1,13 @@
+import pytest
+
+from layerforge.models.slicing.slicer_service import SlicerService
+
+@pytest.mark.parametrize("total_height,layer_height,expected", [
+    (10, 3, [0, 3, 6, 9, 10]),
+    (9, 3, [0, 3, 6, 9]),
+    (5, 2, [0, 2, 4, 5]),
+])
+def test_calculate_slice_positions(total_height, layer_height, expected):
+    positions = SlicerService.calculate_slice_positions(total_height, layer_height)
+    assert positions == expected
+    assert positions[-1] == total_height


### PR DESCRIPTION
## Summary
- use `math.ceil` when calculating slice positions
- append end height so last slice matches the model
- add unit tests for slicer slice counts

## Testing
- `pip install shapely trimesh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847bb21bf308333a3c18570b467bc40