### PR TITLE
Add direction support to Arrow drawing

### DIFF
--- a/layerforge/domain/shapes/arrow.py
+++ b/layerforge/domain/shapes/arrow.py
@@ -7,6 +7,8 @@ from .base_shape import BaseShape
 class Arrow(BaseShape):
     """An arrow shape for reference marks."""
 
+    direction: float = 0.0
+
     def type(self) -> str:
         """Return the type of the shape. Always 'arrow' for this class.
 

--- a/layerforge/svg/drawing/strategies/arrow_strategy.py
+++ b/layerforge/svg/drawing/strategies/arrow_strategy.py
@@ -19,15 +19,32 @@ class ArrowDrawingStrategy(ShapeDrawingStrategy):
         arrow : Arrow
             The Arrow shape to draw.
         """
-        # TODO: Add some of this as attributes to the Arrow class
-        angle = 90  # TODO: Determine if a direction should be added to the arrow
-        end = (arrow.x + arrow.size * math.cos(angle),
-               arrow.y + arrow.size * math.sin(angle))
-        # TODO: Get stroke and fill from the shape or config
+        angle = arrow.direction
+        if abs(angle) > 2 * math.pi:
+            angle = math.radians(angle)
+
+        end = (
+            arrow.x + arrow.size * math.cos(angle),
+            arrow.y + arrow.size * math.sin(angle),
+        )
+
+        head = arrow.size * 0.2
+
         dwg.add(dwg.line((arrow.x, arrow.y), end, stroke='black'))
-        dwg.add(dwg.polygon(
-            [end,
-             (end[0] - 10 * math.cos(angle + math.pi / 6), end[1] - 10 * math.sin(angle + math.pi / 6)),
-             (end[0] - 10 * math.cos(angle - math.pi / 6),
-              end[1] - 10 * math.sin(angle - math.pi / 6))],
-            fill='none', stroke='black'))
+        dwg.add(
+            dwg.polygon(
+                [
+                    end,
+                    (
+                        end[0] - head * math.cos(angle + math.pi / 6),
+                        end[1] - head * math.sin(angle + math.pi / 6),
+                    ),
+                    (
+                        end[0] - head * math.cos(angle - math.pi / 6),
+                        end[1] - head * math.sin(angle - math.pi / 6),
+                    ),
+                ],
+                fill="none",
+                stroke="black",
+            )
+        )

--- a/tests/test_arrow_drawing_strategy.py
+++ b/tests/test_arrow_drawing_strategy.py
@@ -1,0 +1,27 @@
+import math
+import svgwrite
+from layerforge.svg.drawing.strategies.arrow_strategy import ArrowDrawingStrategy
+from layerforge.domain.shapes import Arrow
+
+
+def _line_end(dwg: svgwrite.Drawing) -> tuple:
+    line = [el for el in dwg.elements if isinstance(el, svgwrite.shapes.Line)][0]
+    return float(line["x2"]), float(line["y2"])
+
+
+def test_arrow_endpoint_degrees():
+    arrow = Arrow(0, 0, 10, direction=90)
+    dwg = svgwrite.Drawing()
+    ArrowDrawingStrategy().draw(dwg, arrow)
+    x2, y2 = _line_end(dwg)
+    assert math.isclose(x2, 0.0, abs_tol=1e-6)
+    assert math.isclose(y2, 10.0, abs_tol=1e-6)
+
+
+def test_arrow_endpoint_radians():
+    arrow = Arrow(0, 0, 10, direction=math.pi / 2)
+    dwg = svgwrite.Drawing()
+    ArrowDrawingStrategy().draw(dwg, arrow)
+    x2, y2 = _line_end(dwg)
+    assert math.isclose(x2, 0.0, abs_tol=1e-6)
+    assert math.isclose(y2, 10.0, abs_tol=1e-6)


### PR DESCRIPTION
## Summary
- extend `Arrow` dataclass with new `direction` field
- update `ArrowDrawingStrategy` to honor angle in degrees or radians
- compute arrowhead size based on arrow length
- add tests for drawing strategy endpoint calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c86ddad88333ad7eb5f8450ba8f7