### PR TITLE
Handle optional deps in tests

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -69,3 +69,10 @@
         3. Annotate the slice with its number within the contour area.
 6. Output:
     1. Save the generated SVG files to the specified output directory, with each file representing a slice of the original 3D model.
+
+## Running the Tests
+
+The test suite depends on optional libraries such as `shapely` and `trimesh`. Each
+test module calls `pytest.importorskip` for these imports so that tests are
+skipped if the dependencies are unavailable. Install these packages to execute
+the entire suite.

--- a/tests/test_arrow_drawing_strategy.py
+++ b/tests/test_arrow_drawing_strategy.py
@@ -1,4 +1,7 @@
 import math
+import pytest
+pytest.importorskip("svgwrite")
+pytest.importorskip("shapely")
 import svgwrite
 from layerforge.svg.drawing.strategies.arrow_strategy import ArrowDrawingStrategy
 from layerforge.domain.shapes import Arrow

--- a/tests/test_calculator_get_potential_marks.py
+++ b/tests/test_calculator_get_potential_marks.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("shapely")
 from shapely.geometry import Polygon, Point
 import random
 

--- a/tests/test_reference_mark_adjuster.py
+++ b/tests/test_reference_mark_adjuster.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("shapely")
 from shapely.geometry import Polygon
 
 import importlib.util

--- a/tests/test_reference_mark_adjuster_extra.py
+++ b/tests/test_reference_mark_adjuster_extra.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("shapely")
 from shapely.geometry import Polygon
 
 from layerforge.models.reference_marks import (

--- a/tests/test_reference_mark_calculator.py
+++ b/tests/test_reference_mark_calculator.py
@@ -4,6 +4,7 @@ import types
 from pathlib import Path
 
 import pytest
+pytest.importorskip("shapely")
 from shapely.geometry import Polygon, Point
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_reference_mark_manager.py
+++ b/tests/test_reference_mark_manager.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.importorskip("trimesh")
+pytest.importorskip("shapely")
 from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMark
 
 

--- a/tests/test_slice_process_reference_marks.py
+++ b/tests/test_slice_process_reference_marks.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("shapely")
 from shapely.geometry import Polygon
 
 from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig

--- a/tests/test_slicer_service.py
+++ b/tests/test_slicer_service.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("trimesh")
 
 from layerforge.models.slicing.slicer_service import SlicerService
 


### PR DESCRIPTION
## Summary
- skip shapely or trimesh dependent tests if the deps are missing
- mention this optional dependency behavior in development docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ce0f87288333b227a35d9edf403e