### PR TITLE
Refactor CLI processing

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,58 @@
+from click.testing import CliRunner
+
+from layerforge import cli as cli_module
+cli = cli_module.cli
+
+
+def test_cli_delegates_to_process_model(monkeypatch):
+    runner = CliRunner()
+    called = {}
+
+    def fake_process_model(**kwargs):
+        called.update(kwargs)
+
+    monkeypatch.setattr(cli_module, "process_model", fake_process_model)
+
+    result = runner.invoke(
+        cli,
+        [
+            "--stl-file",
+            "model.stl",
+            "--layer-height",
+            "1.0",
+            "--output-folder",
+            "out",
+            "--scale-factor",
+            "2.0",
+        ],
+    )
+    assert result.exit_code == 0
+    assert called["stl_file"] == "model.stl"
+    assert called["layer_height"] == 1.0
+    assert called["output_folder"] == "out"
+    assert called["scale_factor"] == 2.0
+    assert called["target_height"] is None
+    assert called["available_shapes"] == "circle,square,triangle,arrow"
+
+
+def test_cli_conflicting_options(monkeypatch):
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "--stl-file",
+            "model.stl",
+            "--layer-height",
+            "0.5",
+            "--output-folder",
+            "out",
+            "--scale-factor",
+            "1.0",
+            "--target-height",
+            "10.0",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Only one of scale_factor or target_height can be provided." in result.output


### PR DESCRIPTION
## Summary
- refactor `process_model` to accept CLI args and drive the whole workflow
- simplify CLI command to delegate straight to `process_model`
- add tests covering the CLI via `click.testing.CliRunner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cfaa4bac83338782ccda23de8304