### PR TITLE
Add orientation and color support for shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The CLI exposes parameters for tuning reference mark generation:
 - `--mark-tolerance` – distance used when matching an existing mark. Defaults to `10.0`.
 - `--mark-min-distance` – minimum distance from contours and between marks. Defaults to `10.0`.
 - `--available-shapes` – comma separated list of shapes to cycle through when creating marks. Defaults to `circle,square,triangle,arrow`.
+- `--mark-angle` – default orientation angle for generated marks in degrees.
+- `--mark-color` – outline color for reference marks.
 
 See [docs/configuration.md](docs/configuration.md) for full details on how these
 options influence mark placement.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,9 +8,11 @@ configuration options or the equivalent CLI arguments:
 - `tolerance` – distance used when matching an existing mark.
 - `min_distance` – minimum distance a mark must maintain from contours and other marks.
 - `available_shapes` – list of shapes that will be cycled through when creating new marks.
+- `angle` – default orientation angle for generated marks in degrees.
+- `color` – outline color used when drawing marks.
 
-These correspond to the CLI flags `--mark-tolerance`, `--mark-min-distance` and
-`--available-shapes` respectively.
+These correspond to the CLI flags `--mark-tolerance`, `--mark-min-distance`,
+`--available-shapes`, `--mark-angle` and `--mark-color` respectively.
 
 ### Workflow
 

--- a/layerforge/cli.py
+++ b/layerforge/cli.py
@@ -1,4 +1,5 @@
 import sys
+import math
 
 import click
 
@@ -21,6 +22,8 @@ def process_model(
     mark_tolerance: float = 10.0,
     mark_min_distance: float = 10.0,
     available_shapes: str = "circle,square,triangle,arrow",
+    mark_angle: float = 0.0,
+    mark_color: str | None = None,
 ) -> None:
     """Process the model and generate SVG slices.
 
@@ -43,6 +46,10 @@ def process_model(
         Minimum distance from contours and between marks.
     available_shapes : str
         Comma separated list of shapes used for new marks.
+    mark_angle : float
+        Default orientation angle for marks in degrees.
+    mark_color : str, optional
+        Default color for mark outlines.
 
     Returns
     -------
@@ -65,6 +72,8 @@ def process_model(
         tolerance=mark_tolerance,
         min_distance=mark_min_distance,
         available_shapes=[s.strip() for s in available_shapes.split(",") if s.strip()],
+        angle=math.radians(mark_angle),
+        color=mark_color,
     )
 
     slices = SlicerService.slice_model(model, config=config)
@@ -82,6 +91,8 @@ def process_model(
 @click.option('--mark-tolerance', default=10.0, type=float, help='Tolerance when matching existing marks.')
 @click.option('--mark-min-distance', default=10.0, type=float, help='Minimum distance from contours and between marks.')
 @click.option('--available-shapes', default='circle,square,triangle,arrow', help='Comma separated list of mark shapes.')
+@click.option('--mark-angle', default=0.0, type=float, help='Default mark orientation in degrees.')
+@click.option('--mark-color', default=None, help='Outline color for marks.')
 def cli(
     stl_file: str,
     layer_height: float,
@@ -91,6 +102,8 @@ def cli(
     mark_tolerance: float,
     mark_min_distance: float,
     available_shapes: str,
+    mark_angle: float,
+    mark_color: str,
 ) -> None:
     """Entry point for the CLI.
 
@@ -124,6 +137,8 @@ def cli(
         mark_tolerance=mark_tolerance,
         mark_min_distance=mark_min_distance,
         available_shapes=available_shapes,
+        mark_angle=mark_angle,
+        mark_color=mark_color,
     )
 
 

--- a/layerforge/domain/shapes/arrow.py
+++ b/layerforge/domain/shapes/arrow.py
@@ -7,8 +7,6 @@ from .base_shape import BaseShape
 class Arrow(BaseShape):
     """An arrow shape for reference marks."""
 
-    direction: float = 0.0
-
     def type(self) -> str:
         """Return the type of the shape. Always 'arrow' for this class.
 

--- a/layerforge/domain/shapes/base_shape.py
+++ b/layerforge/domain/shapes/base_shape.py
@@ -18,6 +18,8 @@ class BaseShape(ABC):
     x: float
     y: float
     size: float
+    angle: float = 0.0
+    color: str | None = None
 
     @abstractmethod
     def type(self) -> str:

--- a/layerforge/models/reference_marks/config.py
+++ b/layerforge/models/reference_marks/config.py
@@ -10,3 +10,5 @@ class ReferenceMarkConfig:
     available_shapes: List[str] = field(
         default_factory=lambda: ["circle", "square", "triangle", "arrow"]
     )
+    angle: float = 0.0
+    color: str | None = None

--- a/layerforge/models/reference_marks/reference_mark.py
+++ b/layerforge/models/reference_marks/reference_mark.py
@@ -8,3 +8,5 @@ class ReferenceMark:
     y: float
     shape: str
     size: float
+    angle: float = 0.0
+    color: str | None = None

--- a/layerforge/models/reference_marks/reference_mark_manager.py
+++ b/layerforge/models/reference_marks/reference_mark_manager.py
@@ -31,14 +31,18 @@ class ReferenceMarkManager:
                 return mark
         return None
 
-    def add_or_update_mark(self, x: float, y: float, shape: str, size: float) -> None:
+    def add_or_update_mark(
+        self, x: float, y: float, shape: str, size: float, *, angle: float = 0.0, color: str | None = None
+    ) -> None:
         """Add a new mark or update an existing one."""
         mark = self.find_mark_by_position(x, y)
         if mark:
             mark.shape = shape
             mark.size = size
         else:
-            self.marks.append(ReferenceMark(x=x, y=y, shape=shape, size=size))
+            self.marks.append(
+                ReferenceMark(x=x, y=y, shape=shape, size=size, angle=angle, color=color)
+            )
 
     def find_mark_in_polygon(self, polygon: Polygon, min_distance: float | None = None) -> Optional[ReferenceMark]:
         """Return a stored mark inside ``polygon`` respecting ``min_distance``."""

--- a/layerforge/models/slicing/slice.py
+++ b/layerforge/models/slicing/slice.py
@@ -86,13 +86,36 @@ class Slice:
             )
             if existing_mark:
                 self.ref_marks.append(
-                    ReferenceMark(x=x, y=y, shape=existing_mark.shape, size=existing_mark.size)
+                    ReferenceMark(
+                        x=x,
+                        y=y,
+                        shape=existing_mark.shape,
+                        size=existing_mark.size,
+                        angle=self.config.angle,
+                        color=self.config.color,
+                    )
                 )
             else:
                 new_shape = self._select_unique_shape()
                 new_size = self._calculate_mark_size(x, y)
-                self.mark_manager.add_or_update_mark(x, y, new_shape, new_size)
-                self.ref_marks.append(ReferenceMark(x=x, y=y, shape=new_shape, size=new_size))
+                self.mark_manager.add_or_update_mark(
+                    x,
+                    y,
+                    new_shape,
+                    new_size,
+                    angle=self.config.angle,
+                    color=self.config.color,
+                )
+                self.ref_marks.append(
+                    ReferenceMark(
+                        x=x,
+                        y=y,
+                        shape=new_shape,
+                        size=new_size,
+                        angle=self.config.angle,
+                        color=self.config.color,
+                    )
+                )
 
     def adjust_marks(self) -> None:
         """Adjust reference marks for the slice.

--- a/layerforge/svg/drawing/strategies/arrow_strategy.py
+++ b/layerforge/svg/drawing/strategies/arrow_strategy.py
@@ -19,7 +19,7 @@ class ArrowDrawingStrategy(ShapeDrawingStrategy):
         arrow : Arrow
             The Arrow shape to draw.
         """
-        angle = arrow.direction
+        angle = arrow.angle
         if abs(angle) > 2 * math.pi:
             angle = math.radians(angle)
 
@@ -30,7 +30,8 @@ class ArrowDrawingStrategy(ShapeDrawingStrategy):
 
         head = arrow.size * 0.2
 
-        dwg.add(dwg.line((arrow.x, arrow.y), end, stroke='black'))
+        stroke_color = arrow.color or 'black'
+        dwg.add(dwg.line((arrow.x, arrow.y), end, stroke=stroke_color))
         dwg.add(
             dwg.polygon(
                 [
@@ -45,6 +46,6 @@ class ArrowDrawingStrategy(ShapeDrawingStrategy):
                     ),
                 ],
                 fill="none",
-                stroke="black",
+                stroke=stroke_color,
             )
         )

--- a/layerforge/svg/drawing/strategies/circle_strategy.py
+++ b/layerforge/svg/drawing/strategies/circle_strategy.py
@@ -1,3 +1,4 @@
+import math
 from svgwrite import Drawing
 
 from layerforge.domain.shapes import Circle
@@ -21,5 +22,11 @@ class CircleDrawingStrategy(ShapeDrawingStrategy):
         -------
         None
         """
-        # TODO: Get stroke and fill from the shape or config
-        dwg.add(dwg.circle(center=(circle.x, circle.y), r=circle.radius, stroke='red', fill='none'))
+        color = circle.color or 'red'
+        # rotation has no visible effect for circles but is kept for consistency
+        element = dwg.circle(
+            center=(circle.x, circle.y), r=circle.radius, stroke=color, fill='none'
+        )
+        if circle.angle:
+            element.rotate(math.degrees(circle.angle), center=(circle.x, circle.y))
+        dwg.add(element)

--- a/layerforge/svg/drawing/strategies/square_strategy.py
+++ b/layerforge/svg/drawing/strategies/square_strategy.py
@@ -1,3 +1,4 @@
+import math
 from svgwrite import Drawing
 
 from layerforge.domain.shapes import Square
@@ -21,7 +22,13 @@ class SquareDrawingStrategy(ShapeDrawingStrategy):
         -------
         None
         """
-        # TODO: Get stroke and fill from the shape or config
-        # TODO: Add some of this as attributes to the Square class
-        dwg.add(dwg.rect(insert=(square.x - square.size / 2, square.y - square.size / 2),
-                         size=(square.size, square.size), stroke='blue', fill='none'))
+        color = square.color or 'blue'
+        element = dwg.rect(
+            insert=(square.x - square.size / 2, square.y - square.size / 2),
+            size=(square.size, square.size),
+            stroke=color,
+            fill='none',
+        )
+        if square.angle:
+            element.rotate(math.degrees(square.angle), center=(square.x, square.y))
+        dwg.add(element)

--- a/layerforge/svg/drawing/strategies/triangle_strategy.py
+++ b/layerforge/svg/drawing/strategies/triangle_strategy.py
@@ -1,3 +1,4 @@
+import math
 from svgwrite import Drawing
 
 from layerforge.domain.shapes import Triangle
@@ -21,5 +22,15 @@ class TriangleDrawingStrategy(ShapeDrawingStrategy):
         -------
         None
         """
-        # TODO: Get stroke and fill from the shape or config
-        dwg.add(dwg.polygon(triangle.vertices, stroke='green', fill='none'))
+        color = triangle.color or 'green'
+        verts = triangle.vertices
+        if triangle.angle:
+            verts = []
+            cx, cy = triangle.x, triangle.y
+            for x, y in triangle.vertices:
+                dx, dy = x - cx, y - cy
+                r = math.hypot(dx, dy)
+                theta = math.atan2(dy, dx) + triangle.angle
+                verts.append((cx + r * math.cos(theta), cy + r * math.sin(theta)))
+
+        dwg.add(dwg.polygon(verts, stroke=color, fill='none'))

--- a/layerforge/svg/slice_svg_drawer.py
+++ b/layerforge/svg/slice_svg_drawer.py
@@ -45,7 +45,14 @@ class SliceSVGDrawer:
         None
         """
         for mark in ref_marks:
-            shape_instance = ShapeFactory.get_shape(mark[2], *mark[:2], size=mark[3])
+            shape_instance = ShapeFactory.get_shape(
+                mark.shape,
+                mark.x,
+                mark.y,
+                size=mark.size,
+                angle=mark.angle,
+                color=mark.color,
+            )
             if shape_instance:
                 shape_context.draw(dwg, shape_instance)
 

--- a/tests/test_arrow_drawing_strategy.py
+++ b/tests/test_arrow_drawing_strategy.py
@@ -13,16 +13,18 @@ def _line_end(dwg: svgwrite.Drawing) -> tuple:
 
 
 def test_arrow_endpoint_degrees():
-    arrow = Arrow(0, 0, 10, direction=90)
+    arrow = Arrow(0, 0, 10, angle=90, color="purple")
     dwg = svgwrite.Drawing()
     ArrowDrawingStrategy().draw(dwg, arrow)
     x2, y2 = _line_end(dwg)
+    line = [el for el in dwg.elements if isinstance(el, svgwrite.shapes.Line)][0]
+    assert line["stroke"] == "purple"
     assert math.isclose(x2, 0.0, abs_tol=1e-6)
     assert math.isclose(y2, 10.0, abs_tol=1e-6)
 
 
 def test_arrow_endpoint_radians():
-    arrow = Arrow(0, 0, 10, direction=math.pi / 2)
+    arrow = Arrow(0, 0, 10, angle=math.pi / 2)
     dwg = svgwrite.Drawing()
     ArrowDrawingStrategy().draw(dwg, arrow)
     x2, y2 = _line_end(dwg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,8 @@ def test_cli_delegates_to_process_model(monkeypatch):
     assert called["scale_factor"] == 2.0
     assert called["target_height"] is None
     assert called["available_shapes"] == "circle,square,triangle,arrow"
+    assert called["mark_angle"] == 0.0
+    assert called["mark_color"] is None
 
 
 def test_cli_conflicting_options(monkeypatch):


### PR DESCRIPTION
## Summary
- add `angle` and `color` attributes to `BaseShape` and `ReferenceMark`
- pass new defaults through `ReferenceMarkConfig`
- update CLI to expose `--mark-angle` and `--mark-color`
- rotate/colour shapes in drawing strategies
- adjust slice mark generation to use config values
- update documentation and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848657e20688333878ff96f7c8573f6