### PR TITLE
Add shape registry to factory

### DIFF
--- a/layerforge/svg/drawing/shape_factory.py
+++ b/layerforge/svg/drawing/shape_factory.py
@@ -1,27 +1,37 @@
-from layerforge.domain.shapes import Circle, Square, Triangle, Arrow
+"""Factory utilities for creating shape instances."""
+
+from layerforge.domain.shapes import Arrow, Circle, Square, Triangle
+
+# Registry mapping shape names to their implementing classes
+_SHAPE_REGISTRY: dict[str, type] = {
+    "circle": Circle,
+    "square": Square,
+    "triangle": Triangle,
+    "arrow": Arrow,
+}
+
+
+def register_shape(name: str, cls: type) -> None:
+    """Register ``cls`` under ``name`` in the factory registry."""
+    _SHAPE_REGISTRY[name] = cls
 
 
 class ShapeFactory:
     """Factory class for creating shapes."""
     @staticmethod
     def get_shape(shape_type: str, *args, **kwargs) -> object:
-        """Return a shape object based on the shape type.
+        """Return an instance of the shape registered under ``shape_type``.
 
-        Parameters
-        ----------
-        shape_type : str
-            The type of shape to create.
+        Raises
+        ------
+        ValueError
+            If ``shape_type`` has not been registered.
         """
-        # TODO: Research type hints for return value and BaseShape
-        # TODO: Update docstring after refactoring out args and kwargs
-        # TODO: Update this to use a registry of shape types
-        if shape_type == 'circle':
-            return Circle(*args, **kwargs)
-        elif shape_type == 'square':
-            return Square(*args, **kwargs)
-        elif shape_type == 'triangle':
-            return Triangle(*args, **kwargs)
-        elif shape_type == 'arrow':
-            return Arrow(*args, **kwargs)
-        else:
-            raise ValueError(f"Unknown shape type: {shape_type}")
+
+        shape_cls = _SHAPE_REGISTRY.get(shape_type)
+        if not shape_cls:
+            available = ", ".join(sorted(_SHAPE_REGISTRY))
+            raise ValueError(
+                f"Unknown shape type: {shape_type}. Available shapes: {available}"
+            )
+        return shape_cls(*args, **kwargs)

--- a/layerforge/svg/slice_svg_drawer.py
+++ b/layerforge/svg/slice_svg_drawer.py
@@ -53,8 +53,7 @@ class SliceSVGDrawer:
                 angle=mark.angle,
                 color=mark.color,
             )
-            if shape_instance:
-                shape_context.draw(dwg, shape_instance)
+            shape_context.draw(dwg, shape_instance)
 
     @staticmethod
     def draw_slice(dwg: Drawing, slice_obj: Slice, shape_context: StrategyContext) -> None:

--- a/tests/test_shape_factory.py
+++ b/tests/test_shape_factory.py
@@ -1,0 +1,23 @@
+import pytest
+
+from layerforge.svg.drawing.shape_factory import ShapeFactory, register_shape
+from layerforge.domain.shapes.base_shape import BaseShape
+
+
+class MockShape(BaseShape):
+    def type(self) -> str:
+        return "mock"
+
+
+def test_register_and_retrieve_shape():
+    register_shape("mock", MockShape)
+    shape = ShapeFactory.get_shape("mock", 1, 2, 3)
+    assert isinstance(shape, MockShape)
+    assert shape.x == 1
+    assert shape.y == 2
+    assert shape.size == 3
+
+
+def test_unknown_shape_error():
+    with pytest.raises(ValueError):
+        ShapeFactory.get_shape("unknown", 0, 0, 1)


### PR DESCRIPTION
## Summary
- implement registry for shapes and register built-ins
- remove conditional dispatch in `ShapeFactory.get_shape`
- update `SliceSVGDrawer` to use factory output directly
- add tests for `register_shape` and unknown shapes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684899e5e4048333a4f56740eed01f3c