### PR TITLE
Make helper methods static

### DIFF
--- a/layerforge/models/model_factory.py
+++ b/layerforge/models/model_factory.py
@@ -45,12 +45,12 @@ class ModelFactory:
         """
         mesh = self.mesh_loader.load_mesh(model_file)
         # TODO: Add a check for List[Trimesh]/List[Geometry] and throw an error if it is not a single mesh.
-        mesh = self._scale_mesh(mesh, scale_factor, target_height)
-        origin = self._calculate_origin(mesh)
+        mesh = ModelFactory._scale_mesh(mesh, scale_factor, target_height)
+        origin = ModelFactory._calculate_origin(mesh)
         return Model(mesh, layer_height, origin)
 
-    # TODO: Investigate if _scale_mesh needs to be converted to a static method or the class refactored.
-    def _scale_mesh(self, mesh: Trimesh, scale_factor: float = None, target_height: float = None) -> Trimesh:
+    @staticmethod
+    def _scale_mesh(mesh: Trimesh, scale_factor: float = None, target_height: float = None) -> Trimesh:
         """Scale the mesh based on the scale factor or target height.
 
         Parameters
@@ -82,8 +82,8 @@ class ModelFactory:
             mesh.apply_scale(scale_factor)
         return mesh
 
-    # TODO: Investigate if _calculate_origin needs to be converted to a static method or the class refactored.
-    def _calculate_origin(self, mesh: Trimesh) -> tuple:
+    @staticmethod
+    def _calculate_origin(mesh: Trimesh) -> tuple:
         """Calculate the (x,y) origin of the mesh.
 
         Parameters

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,0 +1,40 @@
+import pytest
+pytest.importorskip("trimesh")
+
+import trimesh
+from layerforge.models.model_factory import ModelFactory
+from layerforge.models.loading.base import MeshLoader
+
+
+class DummyLoader(MeshLoader):
+    def __init__(self, mesh):
+        self.mesh = mesh
+
+    def load_mesh(self, model_file: str):
+        # return a copy to avoid modifying original
+        return self.mesh.copy()
+
+
+def test_scale_mesh_by_factor():
+    mesh = trimesh.creation.box(extents=(1, 1, 1))
+    scaled = ModelFactory._scale_mesh(mesh.copy(), scale_factor=2)
+    assert pytest.approx(scaled.extents.tolist()) == [2.0, 2.0, 2.0]
+
+
+def test_scale_mesh_by_target_height():
+    mesh = trimesh.creation.box(extents=(1, 1, 1))
+    scaled = ModelFactory._scale_mesh(mesh.copy(), target_height=5)
+    assert pytest.approx(scaled.bounds[1][2] - scaled.bounds[0][2]) == 5.0
+
+
+def test_scale_mesh_conflict():
+    mesh = trimesh.creation.box(extents=(1, 1, 1))
+    with pytest.raises(ValueError):
+        ModelFactory._scale_mesh(mesh, scale_factor=1, target_height=2)
+
+
+def test_calculate_origin():
+    mesh = trimesh.creation.box(extents=(1, 2, 3))
+    mesh.apply_translation([1, 2, 3])
+    origin = ModelFactory._calculate_origin(mesh)
+    assert pytest.approx(origin) == (1.0, 2.0)


### PR DESCRIPTION
## Summary
- refactor ModelFactory helper methods to static methods
- add unit tests for mesh scaling and origin calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b5276fec833390f7aef9ec99faab