### PR TITLE
Add trimesh example and integration test

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -13,3 +13,14 @@
    ```bash
    python -c "import layerforge; print(layerforge.__version__)"
    ```
+
+## Example
+
+To try LayerForge without providing your own STL file, run the sample script:
+
+```bash
+python scripts/simple_mesh_example.py
+```
+
+This generates a basic cube mesh, slices it, and writes SVG files to the
+`example_output/` directory.

--- a/scripts/simple_mesh_example.py
+++ b/scripts/simple_mesh_example.py
@@ -1,0 +1,22 @@
+import tempfile
+from pathlib import Path
+
+import trimesh
+
+from layerforge.cli import process_model
+
+
+def run_example(output_folder: str = "example_output") -> None:
+    """Generate a box mesh and slice it with :func:`process_model`."""
+    mesh = trimesh.creation.box(extents=(20, 20, 20))
+    with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as tmp:
+        mesh.export(tmp.name)
+        stl_path = tmp.name
+    try:
+        process_model(stl_file=stl_path, layer_height=5.0, output_folder=output_folder)
+    finally:
+        Path(stl_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    run_example()

--- a/tests/test_example_integration.py
+++ b/tests/test_example_integration.py
@@ -1,0 +1,22 @@
+import pytest
+pytest.importorskip("trimesh")
+pytest.importorskip("svgwrite")
+pytest.importorskip("shapely")
+
+from scripts.simple_mesh_example import run_example
+
+
+def test_example_generates_svgs(tmp_path):
+    out_dir = tmp_path / "svgs"
+    run_example(output_folder=str(out_dir))
+
+    files = sorted(out_dir.glob("slice_*.svg"))
+    assert files, "no svg files generated"
+
+    found_mark = False
+    for fp in files:
+        txt = fp.read_text()
+        if any(color in txt for color in ["stroke=\"red\"", "stroke=\"blue\"", "stroke=\"green\""]):
+            found_mark = True
+            break
+    assert found_mark, "no reference marks found in SVGs"


### PR DESCRIPTION
## Summary
- add a sample script that builds a small mesh and invokes `process_model`
- document running the example in `getting_started.md`
- add integration test exercising the example script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bf93c5a483339b4dc3949c2a9b51