### PR TITLE
Handle multiple meshes

### DIFF
--- a/layerforge/models/loading/implementations/trimesh_loader.py
+++ b/layerforge/models/loading/implementations/trimesh_loader.py
@@ -7,7 +7,10 @@ from layerforge.models.loading.base import MeshLoader
 
 class TrimeshLoader(MeshLoader):
     """Loader for trimesh library."""
-    def load_mesh(self, model_file: str) -> Union[trimesh.Geometry, List[trimesh.Geometry]]:
+
+    def load_mesh(
+        self, model_file: str
+    ) -> Union[trimesh.Geometry, List[trimesh.Geometry]]:
         """Load a mesh from a file using the trimesh library.
 
         Parameters
@@ -21,5 +24,9 @@ class TrimeshLoader(MeshLoader):
             The loaded mesh or meshes.
         """
         # TODO: Investigate encapsulating mesh in a custom object to abstract the specific library that is used.
-        # TODO: Research if it is appropriate to throw an exception here if a list of meshes is returned.
-        return trimesh.load_mesh(model_file)
+        mesh = trimesh.load_mesh(model_file)
+        if isinstance(mesh, list):
+            raise ValueError(
+                f"File '{model_file}' contains {len(mesh)} geometries; only a single mesh is supported."
+            )
+        return mesh

--- a/layerforge/models/model_factory.py
+++ b/layerforge/models/model_factory.py
@@ -23,8 +23,13 @@ class ModelFactory:
         """
         self.mesh_loader = mesh_loader
 
-    def create_model(self, model_file: str, layer_height: float, scale_factor: float = None,
-                     target_height: float = None) -> Model:
+    def create_model(
+        self,
+        model_file: str,
+        layer_height: float,
+        scale_factor: float = None,
+        target_height: float = None,
+    ) -> Model:
         """Create a Model object from an STL file.
 
         Parameters
@@ -44,13 +49,18 @@ class ModelFactory:
             The Model object created from the STL file.
         """
         mesh = self.mesh_loader.load_mesh(model_file)
-        # TODO: Add a check for List[Trimesh]/List[Geometry] and throw an error if it is not a single mesh.
+        if isinstance(mesh, list):
+            raise ValueError(
+                f"Expected a single mesh from '{model_file}', got {len(mesh)} meshes"
+            )
         mesh = ModelFactory._scale_mesh(mesh, scale_factor, target_height)
         origin = ModelFactory._calculate_origin(mesh)
         return Model(mesh, layer_height, origin)
 
     @staticmethod
-    def _scale_mesh(mesh: Trimesh, scale_factor: float = None, target_height: float = None) -> Trimesh:
+    def _scale_mesh(
+        mesh: Trimesh, scale_factor: float = None, target_height: float = None
+    ) -> Trimesh:
         """Scale the mesh based on the scale factor or target height.
 
         Parameters
@@ -73,7 +83,9 @@ class ModelFactory:
             If both scale_factor and target_height are provided.
         """
         if scale_factor and target_height:
-            raise ValueError("Only one of scale_factor or target_height can be provided.")
+            raise ValueError(
+                "Only one of scale_factor or target_height can be provided."
+            )
         if scale_factor:
             mesh.apply_scale(scale_factor)
         elif target_height:

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,4 +1,5 @@
 import pytest
+
 pytest.importorskip("trimesh")
 
 import trimesh
@@ -38,3 +39,18 @@ def test_calculate_origin():
     mesh.apply_translation([1, 2, 3])
     origin = ModelFactory._calculate_origin(mesh)
     assert pytest.approx(origin) == (1.0, 2.0)
+
+
+class ListLoader(MeshLoader):
+    def load_mesh(self, model_file: str):
+        return [
+            trimesh.creation.box(extents=(1, 1, 1)),
+            trimesh.creation.box(extents=(2, 2, 2)),
+        ]
+
+
+def test_create_model_with_multiple_meshes_raises():
+    loader = ListLoader()
+    factory = ModelFactory(loader)
+    with pytest.raises(ValueError):
+        factory.create_model("dummy.stl", layer_height=1.0)

--- a/tests/test_trimesh_loader.py
+++ b/tests/test_trimesh_loader.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("trimesh")
+
+import trimesh
+from layerforge.models.loading.implementations.trimesh_loader import TrimeshLoader
+
+
+def test_trimesh_loader_multiple_mesh_error(monkeypatch):
+    mesh1 = trimesh.creation.box()
+    mesh2 = trimesh.creation.box()
+
+    def fake_load_mesh(path):
+        return [mesh1, mesh2]
+
+    loader = TrimeshLoader()
+    monkeypatch.setattr(trimesh, "load_mesh", fake_load_mesh)
+    with pytest.raises(ValueError):
+        loader.load_mesh("dummy.stl")


### PR DESCRIPTION
## Summary
- check for list results in `TrimeshLoader.load_mesh`
- reject multi-mesh results in `ModelFactory.create_model`
- test loader errors for multi-mesh results
- test ModelFactory error for list input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d16174c48333b1ebb986c756d4f0