### PR TITLE
Refactor mark processing

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -70,6 +70,13 @@
 6. Output:
     1. Save the generated SVG files to the specified output directory, with each file representing a slice of the original 3D model.
 
+## Expected Workflow
+
+1. Build a :class:`Model` using :class:`ModelFactory` and the desired mesh loader.
+2. Call :meth:`SlicerService.slice_model` to produce a list of :class:`Slice` objects.
+3. Use :class:`ReferenceMarkService` to process each slice so reference marks are calculated and adjusted.
+4. Pass the processed slices to :class:`SVGGenerator` (via the CLI or directly) to write SVG files.
+
 ## Running the Tests
 
 The test suite depends on optional libraries such as `shapely` and `trimesh`. Each

--- a/layerforge/models/reference_marks/__init__.py
+++ b/layerforge/models/reference_marks/__init__.py
@@ -3,3 +3,5 @@ from .reference_mark_adjuster import ReferenceMarkAdjuster
 from .reference_mark_calculator import ReferenceMarkCalculator
 from .reference_mark_manager import ReferenceMarkManager
 from .config import ReferenceMarkConfig
+
+from .reference_mark_service import ReferenceMarkService

--- a/layerforge/models/reference_marks/reference_mark_service.py
+++ b/layerforge/models/reference_marks/reference_mark_service.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from layerforge.models.slicing.slice import Slice
+
+
+class ReferenceMarkService:
+    """Utility service for processing reference marks on a slice."""
+
+    @staticmethod
+    def process_slice(slice_: "Slice") -> None:
+        """Calculate and adjust reference marks for ``slice_``."""
+        slice_.process_reference_marks()
+        slice_.adjust_marks()
+

--- a/layerforge/models/slicing/slicer_service.py
+++ b/layerforge/models/slicing/slicer_service.py
@@ -2,7 +2,11 @@ from typing import List
 import math
 
 from layerforge.models import Slice, Model
-from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig
+from layerforge.models.reference_marks import (
+    ReferenceMarkManager,
+    ReferenceMarkConfig,
+    ReferenceMarkService,
+)
 
 
 class SlicerService:
@@ -63,8 +67,7 @@ class SlicerService:
                 mark_manager=mark_manager,
                 config=cfg,
             )
-            # TODO: Investigate if this is the best place to process the reference marks
-            slice_.process_reference_marks()
-            slice_.adjust_marks()
+            # Process and adjust reference marks outside of the slicing logic
+            ReferenceMarkService.process_slice(slice_)
             slices.append(slice_)
         return slices

--- a/tests/test_reference_mark_calculator.py
+++ b/tests/test_reference_mark_calculator.py
@@ -44,6 +44,7 @@ pkg_ref.ReferenceMarkCalculator = None
 pkg_ref.ReferenceMark = None
 pkg_ref.ReferenceMarkAdjuster = None
 pkg_ref.ReferenceMarkConfig = None
+pkg_ref.ReferenceMarkService = None
 
 module_name_config = "layerforge.models.reference_marks.config"
 spec_config = importlib.util.spec_from_file_location(
@@ -77,6 +78,16 @@ spec_calc.loader.exec_module(module_calc)  # type: ignore
 ReferenceMarkCalculator = module_calc.ReferenceMarkCalculator
 pkg_ref.ReferenceMarkCalculator = ReferenceMarkCalculator
 
+module_name_service = "layerforge.models.reference_marks.reference_mark_service"
+spec_service = importlib.util.spec_from_file_location(
+    module_name_service, ROOT / "layerforge/models/reference_marks/reference_mark_service.py"
+)
+module_service = importlib.util.module_from_spec(spec_service)
+sys.modules[module_name_service] = module_service
+spec_service.loader.exec_module(module_service)  # type: ignore
+ReferenceMarkService = module_service.ReferenceMarkService
+pkg_ref.ReferenceMarkService = ReferenceMarkService
+
 module_name_mark = "layerforge.models.reference_marks.reference_mark"
 spec_mark = importlib.util.spec_from_file_location(
     module_name_mark, ROOT / "layerforge/models/reference_marks/reference_mark.py"
@@ -107,7 +118,7 @@ def test_inherit_mark_within_polygon():
     manager.add_or_update_mark(50, 50, "circle", 3)
     cfg = ReferenceMarkConfig(min_distance=10)
     sl = Slice(0, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg)
-    sl.process_reference_marks()
+    ReferenceMarkService.process_slice(sl)
     assert len(sl.ref_marks) == 1
     assert sl.ref_marks[0].x == 50
     assert sl.ref_marks[0].y == 50
@@ -118,7 +129,7 @@ def test_generate_mark_respects_boundary():
     manager = ReferenceMarkManager()
     cfg = ReferenceMarkConfig(min_distance=10)
     sl = Slice(1, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg)
-    sl.process_reference_marks()
+    ReferenceMarkService.process_slice(sl)
     assert len(sl.ref_marks) == 1
     pt = Point(sl.ref_marks[0].x, sl.ref_marks[0].y)
     assert square.contains(pt)

--- a/tests/test_slice_process_reference_marks.py
+++ b/tests/test_slice_process_reference_marks.py
@@ -2,7 +2,11 @@ import pytest
 pytest.importorskip("shapely")
 from shapely.geometry import Polygon
 
-from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig
+from layerforge.models.reference_marks import (
+    ReferenceMarkManager,
+    ReferenceMarkConfig,
+    ReferenceMarkService,
+)
 from layerforge.models.slicing.slice import Slice
 
 
@@ -11,7 +15,7 @@ def test_new_mark_added_to_manager():
     manager = ReferenceMarkManager()
     cfg = ReferenceMarkConfig(min_distance=10)
     sl = Slice(0, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg)
-    sl.process_reference_marks()
+    ReferenceMarkService.process_slice(sl)
     assert len(sl.ref_marks) == 1
     # manager should now contain the new mark
     assert len(manager.marks) == 1


### PR DESCRIPTION
## Summary
- add `ReferenceMarkService` to process reference marks for a slice
- use the new service inside `SlicerService`
- document the high level workflow
- update reference mark tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d6ead59c8333af0b80124a4b6780