### PR TITLE
Add optional dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A 3D Model Slicing and SVG Generation Application
 ## Table of Contents
 
 - [Installation](#installation)
+- [Dependencies](#dependencies)
 - [Usage](#usage)
 - [Features](#features)
 - [Configuration](#configuration)
@@ -36,6 +37,16 @@ A 3D Model Slicing and SVG Generation Application
    ```bash
    pip install -r requirements-dev.txt
    ```
+
+## Dependencies
+
+The following Python packages are required at runtime:
+
+- `trimesh` – mesh loading and manipulation
+- `svgwrite` – generating SVG files
+- `shapely` – geometric computations
+
+These packages are installed automatically when installing LayerForge.
 
 ## Usage
 

--- a/layerforge/models/loading/implementations/trimesh_loader.py
+++ b/layerforge/models/loading/implementations/trimesh_loader.py
@@ -1,6 +1,8 @@
 from typing import List, Union
 
-import trimesh
+from layerforge.utils.optional_dependencies import require_module
+
+trimesh = require_module("trimesh", "TrimeshLoader")
 
 from layerforge.models.loading.base import MeshLoader
 

--- a/layerforge/models/model.py
+++ b/layerforge/models/model.py
@@ -1,7 +1,9 @@
 from typing import List, Tuple
 
-from shapely.geometry import Polygon
-from trimesh import Trimesh
+from layerforge.utils.optional_dependencies import require_module
+
+Polygon = require_module("shapely.geometry", "Model").Polygon
+Trimesh = require_module("trimesh", "Model").Trimesh
 
 
 class Model:

--- a/layerforge/models/reference_marks/reference_mark_adjuster.py
+++ b/layerforge/models/reference_marks/reference_mark_adjuster.py
@@ -1,6 +1,10 @@
 from typing import List
 
-from shapely.geometry import Point, Polygon
+from layerforge.utils.optional_dependencies import require_module
+
+_shapely = require_module("shapely.geometry", "ReferenceMarkAdjuster")
+Point = _shapely.Point
+Polygon = _shapely.Polygon
 
 from .reference_mark import ReferenceMark
 from .config import ReferenceMarkConfig

--- a/layerforge/models/reference_marks/reference_mark_calculator.py
+++ b/layerforge/models/reference_marks/reference_mark_calculator.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Tuple
 
-from shapely.geometry import Point, Polygon
+from layerforge.utils.optional_dependencies import require_module
+
+_shapely = require_module("shapely.geometry", "ReferenceMarkCalculator")
+Point = _shapely.Point
+Polygon = _shapely.Polygon
 import random
 
 from layerforge.utils import calculate_distance

--- a/layerforge/models/reference_marks/reference_mark_manager.py
+++ b/layerforge/models/reference_marks/reference_mark_manager.py
@@ -1,6 +1,10 @@
 from typing import List, Optional
 
-from shapely.geometry import Point, Polygon
+from layerforge.utils.optional_dependencies import require_module
+
+_shapely = require_module("shapely.geometry", "ReferenceMarkManager")
+Point = _shapely.Point
+Polygon = _shapely.Polygon
 
 from .config import ReferenceMarkConfig
 

--- a/layerforge/models/slicing/slice.py
+++ b/layerforge/models/slicing/slice.py
@@ -1,7 +1,9 @@
 import logging
 from typing import List
 
-from shapely.geometry import Polygon
+from layerforge.utils.optional_dependencies import require_module
+
+Polygon = require_module("shapely.geometry", "Slice").Polygon
 
 from layerforge.models.reference_marks import (
     ReferenceMark,

--- a/layerforge/svg/drawing/strategies/arrow_strategy.py
+++ b/layerforge/svg/drawing/strategies/arrow_strategy.py
@@ -1,6 +1,8 @@
 import math
 
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "ArrowDrawingStrategy").Drawing
 
 from layerforge.domain.shapes import Arrow
 from .base_strategy import ShapeDrawingStrategy

--- a/layerforge/svg/drawing/strategies/base_strategy.py
+++ b/layerforge/svg/drawing/strategies/base_strategy.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "ShapeDrawingStrategy").Drawing
 
 from layerforge.domain.shapes.base_shape import BaseShape
 

--- a/layerforge/svg/drawing/strategies/circle_strategy.py
+++ b/layerforge/svg/drawing/strategies/circle_strategy.py
@@ -1,5 +1,7 @@
 import math
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "CircleDrawingStrategy").Drawing
 
 from layerforge.domain.shapes import Circle
 from .base_strategy import ShapeDrawingStrategy

--- a/layerforge/svg/drawing/strategies/square_strategy.py
+++ b/layerforge/svg/drawing/strategies/square_strategy.py
@@ -1,5 +1,7 @@
 import math
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "SquareDrawingStrategy").Drawing
 
 from layerforge.domain.shapes import Square
 from .base_strategy import ShapeDrawingStrategy

--- a/layerforge/svg/drawing/strategies/triangle_strategy.py
+++ b/layerforge/svg/drawing/strategies/triangle_strategy.py
@@ -1,5 +1,7 @@
 import math
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "TriangleDrawingStrategy").Drawing
 
 from layerforge.domain.shapes import Triangle
 from .base_strategy import ShapeDrawingStrategy

--- a/layerforge/svg/drawing/strategy_context.py
+++ b/layerforge/svg/drawing/strategy_context.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .strategies.base_strategy import ShapeDrawingStrategy
 
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "StrategyContext").Drawing
 from layerforge.domain.shapes.base_shape import BaseShape
 
 

--- a/layerforge/svg/slice_svg_drawer.py
+++ b/layerforge/svg/slice_svg_drawer.py
@@ -1,5 +1,11 @@
-from shapely.geometry import Polygon, Point
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+_shapely = require_module("shapely.geometry", "SliceSVGDrawer")
+_svgwrite = require_module("svgwrite", "SliceSVGDrawer")
+
+Polygon = _shapely.Polygon
+Point = _shapely.Point
+Drawing = _svgwrite.Drawing
 
 from layerforge.models.slicing import Slice
 from layerforge.svg.drawing.shape_factory import ShapeFactory

--- a/layerforge/svg/svg_generator.py
+++ b/layerforge/svg/svg_generator.py
@@ -1,6 +1,8 @@
 from typing import List
 
-import svgwrite
+from layerforge.utils.optional_dependencies import require_module
+
+svgwrite = require_module("svgwrite", "SVGGenerator")
 
 from layerforge.models.slicing import Slice
 from layerforge.svg.drawing import StrategyContext

--- a/layerforge/utils/__init__.py
+++ b/layerforge/utils/__init__.py
@@ -1,3 +1,5 @@
 from .geometry import calculate_distance
 from .loader_initialization import initialize_loaders
 from .shape_strategies import register_shape_strategies
+from .optional_dependencies import require_module
+

--- a/layerforge/utils/optional_dependencies.py
+++ b/layerforge/utils/optional_dependencies.py
@@ -1,0 +1,13 @@
+from importlib import import_module
+
+
+def require_module(module: str, feature: str):
+    """Import ``module`` or raise an informative :class:`ImportError`."""
+    try:
+        return import_module(module)
+    except ImportError as exc:
+        pkg = module.split(".")[0]
+        raise ImportError(
+            f"{feature} requires the '{pkg}' package. Install it via 'pip install {pkg}'."
+        ) from exc
+

--- a/layerforge/writers/svg_writer.py
+++ b/layerforge/writers/svg_writer.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
-from svgwrite import Drawing
+from layerforge.utils.optional_dependencies import require_module
+
+Drawing = require_module("svgwrite", "SVGWriter").Drawing
 
 from layerforge.utils.file_operations import ensure_directory_exists, generate_file_name
 


### PR DESCRIPTION
## Summary
- ensure shapely, svgwrite and trimesh are checked at import time
- surface `require_module` helper
- document dependencies in README

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684901bd6c488333919a026997f533f9