### PR TITLE
Introduce Mesh abstraction

### DIFF
--- a/layerforge/cli.py
+++ b/layerforge/cli.py
@@ -8,7 +8,8 @@ from layerforge.models.reference_marks import ReferenceMarkConfig
 from layerforge.models.loading import LoaderFactory
 from layerforge.svg import SVGGenerator
 from layerforge.svg.drawing import StrategyContext
-from layerforge.utils import initialize_loaders, register_shape_strategies
+from layerforge.utils import register_shape_strategies
+from layerforge.utils.loader_initialization import initialize_loaders
 from layerforge.writers import SVGFileWriter
 
 

--- a/layerforge/models/loading/__init__.py
+++ b/layerforge/models/loading/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ['LoaderFactory', 'TrimeshLoader']
+__all__ = ["LoaderFactory", "Mesh", "TrimeshLoader"]
 
+from .mesh import Mesh
 from .implementations.trimesh_loader import TrimeshLoader
 
 

--- a/layerforge/models/loading/base.py
+++ b/layerforge/models/loading/base.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 
+from .mesh import Mesh
+
 
 class MeshLoader(ABC):
     """Base class for loading mesh files"""
     @abstractmethod
-    def load_mesh(self, model_file: str) -> object:
+    def load_mesh(self, model_file: str) -> Mesh:
         """Load a mesh file
 
         Parameters
@@ -14,7 +16,7 @@ class MeshLoader(ABC):
 
         Returns
         -------
-        object
-            The loaded mesh. Type depends on the implementation.
+        Mesh
+            The loaded mesh.
         """
         pass

--- a/layerforge/models/loading/implementations/trimesh_loader.py
+++ b/layerforge/models/loading/implementations/trimesh_loader.py
@@ -1,18 +1,17 @@
-from typing import List, Union
+from typing import List
 
 from layerforge.utils.optional_dependencies import require_module
 
 trimesh = require_module("trimesh", "TrimeshLoader")
 
 from layerforge.models.loading.base import MeshLoader
+from layerforge.models.loading.mesh import Mesh
 
 
 class TrimeshLoader(MeshLoader):
     """Loader for trimesh library."""
 
-    def load_mesh(
-        self, model_file: str
-    ) -> Union[trimesh.Geometry, List[trimesh.Geometry]]:
+    def load_mesh(self, model_file: str) -> Mesh:
         """Load a mesh from a file using the trimesh library.
 
         Parameters
@@ -22,8 +21,8 @@ class TrimeshLoader(MeshLoader):
 
         Returns
         -------
-        Union[Geometry, List[Geometry]]
-            The loaded mesh or meshes.
+        Mesh
+            The loaded mesh.
         """
         # TODO: Investigate encapsulating mesh in a custom object to abstract the specific library that is used.
         mesh = trimesh.load_mesh(model_file)
@@ -31,4 +30,4 @@ class TrimeshLoader(MeshLoader):
             raise ValueError(
                 f"File '{model_file}' contains {len(mesh)} geometries; only a single mesh is supported."
             )
-        return mesh
+        return Mesh(mesh)

--- a/layerforge/models/loading/mesh.py
+++ b/layerforge/models/loading/mesh.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+
+@dataclass
+class Mesh:
+    """Lightweight wrapper around an underlying mesh implementation."""
+
+    geometry: Any
+
+    def copy(self) -> "Mesh":
+        """Return a copy of the mesh."""
+        return Mesh(self.geometry.copy())
+
+    def apply_scale(self, scale: float) -> None:
+        self.geometry.apply_scale(scale)
+
+    def apply_translation(self, translation: Sequence[float]) -> None:
+        self.geometry.apply_translation(translation)
+
+    @property
+    def bounds(self):
+        return self.geometry.bounds
+
+    @property
+    def extents(self):
+        return self.geometry.extents
+
+    def section(self, plane_origin, plane_normal):
+        return self.geometry.section(plane_origin=plane_origin, plane_normal=plane_normal)

--- a/layerforge/models/model.py
+++ b/layerforge/models/model.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 from layerforge.utils.optional_dependencies import require_module
 
 Polygon = require_module("shapely.geometry", "Model").Polygon
-Trimesh = require_module("trimesh", "Model").Trimesh
+from .loading.mesh import Mesh
 
 
 class Model:
@@ -11,7 +11,7 @@ class Model:
 
     Attributes
     ----------
-    mesh : trimesh.base.Geometry
+    mesh : Mesh
         The 3D mesh of the model.
     layer_height : float
         The height of each layer that is sliced from the model.
@@ -19,12 +19,12 @@ class Model:
         The origin of the model.
     """
 
-    def __init__(self, mesh: Trimesh, layer_height: float, origin: tuple):
+    def __init__(self, mesh: Mesh, layer_height: float, origin: tuple):
         """Initialize the Model.
 
         Parameters
         ----------
-        mesh : Trimesh
+        mesh : Mesh
             The 3D mesh of the model.
         layer_height : float
             The height of each layer that is sliced from the model.

--- a/layerforge/models/model_factory.py
+++ b/layerforge/models/model_factory.py
@@ -1,6 +1,5 @@
-from trimesh import Trimesh
-
 from .loading.base import MeshLoader
+from .loading.mesh import Mesh
 from .model import Model
 
 
@@ -59,13 +58,13 @@ class ModelFactory:
 
     @staticmethod
     def _scale_mesh(
-        mesh: Trimesh, scale_factor: float = None, target_height: float = None
-    ) -> Trimesh:
+        mesh: Mesh, scale_factor: float = None, target_height: float = None
+    ) -> Mesh:
         """Scale the mesh based on the scale factor or target height.
 
         Parameters
         ----------
-        mesh : Trimesh
+        mesh : Mesh
             The mesh to scale.
         scale_factor : float, optional
             The scale factor to apply to the mesh.
@@ -74,7 +73,7 @@ class ModelFactory:
 
         Returns
         -------
-        Trimesh
+        Mesh
             The scaled mesh.
 
         Raises
@@ -95,12 +94,12 @@ class ModelFactory:
         return mesh
 
     @staticmethod
-    def _calculate_origin(mesh: Trimesh) -> tuple:
+    def _calculate_origin(mesh: Mesh) -> tuple:
         """Calculate the (x,y) origin of the mesh.
 
         Parameters
         ----------
-        mesh : Trimesh
+        mesh : Mesh
             The mesh for which to calculate the origin.
 
         Returns

--- a/layerforge/utils/__init__.py
+++ b/layerforge/utils/__init__.py
@@ -1,5 +1,10 @@
 from .geometry import calculate_distance
-from .loader_initialization import initialize_loaders
 from .shape_strategies import register_shape_strategies
 from .optional_dependencies import require_module
+
+__all__ = [
+    "calculate_distance",
+    "register_shape_strategies",
+    "require_module",
+]
 

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -5,10 +5,11 @@ pytest.importorskip("trimesh")
 import trimesh
 from layerforge.models.model_factory import ModelFactory
 from layerforge.models.loading.base import MeshLoader
+from layerforge.models.loading.mesh import Mesh
 
 
 class DummyLoader(MeshLoader):
-    def __init__(self, mesh):
+    def __init__(self, mesh: Mesh):
         self.mesh = mesh
 
     def load_mesh(self, model_file: str):
@@ -17,25 +18,25 @@ class DummyLoader(MeshLoader):
 
 
 def test_scale_mesh_by_factor():
-    mesh = trimesh.creation.box(extents=(1, 1, 1))
+    mesh = Mesh(trimesh.creation.box(extents=(1, 1, 1)))
     scaled = ModelFactory._scale_mesh(mesh.copy(), scale_factor=2)
-    assert pytest.approx(scaled.extents.tolist()) == [2.0, 2.0, 2.0]
+    assert pytest.approx(scaled.geometry.extents.tolist()) == [2.0, 2.0, 2.0]
 
 
 def test_scale_mesh_by_target_height():
-    mesh = trimesh.creation.box(extents=(1, 1, 1))
+    mesh = Mesh(trimesh.creation.box(extents=(1, 1, 1)))
     scaled = ModelFactory._scale_mesh(mesh.copy(), target_height=5)
     assert pytest.approx(scaled.bounds[1][2] - scaled.bounds[0][2]) == 5.0
 
 
 def test_scale_mesh_conflict():
-    mesh = trimesh.creation.box(extents=(1, 1, 1))
+    mesh = Mesh(trimesh.creation.box(extents=(1, 1, 1)))
     with pytest.raises(ValueError):
         ModelFactory._scale_mesh(mesh, scale_factor=1, target_height=2)
 
 
 def test_calculate_origin():
-    mesh = trimesh.creation.box(extents=(1, 2, 3))
+    mesh = Mesh(trimesh.creation.box(extents=(1, 2, 3)))
     mesh.apply_translation([1, 2, 3])
     origin = ModelFactory._calculate_origin(mesh)
     assert pytest.approx(origin) == (1.0, 2.0)
@@ -44,8 +45,8 @@ def test_calculate_origin():
 class ListLoader(MeshLoader):
     def load_mesh(self, model_file: str):
         return [
-            trimesh.creation.box(extents=(1, 1, 1)),
-            trimesh.creation.box(extents=(2, 2, 2)),
+            Mesh(trimesh.creation.box(extents=(1, 1, 1))),
+            Mesh(trimesh.creation.box(extents=(2, 2, 2))),
         ]
 
 


### PR DESCRIPTION
## Summary
- provide `Mesh` wrapper in `layerforge.models.loading`
- adjust `TrimeshLoader` to return a `Mesh`
- update `Model` and `ModelFactory` to use the new mesh abstraction
- expose the wrapper via `layerforge.models.loading`
- fix circular imports by removing loader initialization from `utils.__init__`
- update CLI and tests for the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684908ad0a488333b28b76b88da23054