### PR TITLE
Add reference mark inheritance test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+pytest.importorskip("trimesh")
+import trimesh
+
+
+@pytest.fixture
+def cylinder_stl(tmp_path):
+    mesh = trimesh.creation.cylinder(radius=30.0, height=10.0)
+    path = tmp_path / "cylinder.stl"
+    mesh.export(path)
+    return path

--- a/tests/test_slice_mark_inheritance.py
+++ b/tests/test_slice_mark_inheritance.py
@@ -1,0 +1,45 @@
+import random
+import xml.etree.ElementTree as ET
+
+import pytest
+
+pytest.importorskip("trimesh")
+pytest.importorskip("svgwrite")
+pytest.importorskip("shapely")
+
+from layerforge.cli import process_model
+
+
+NS = {"svg": "http://www.w3.org/2000/svg"}
+
+
+def _circle_position(svg_file: str) -> tuple[float, float] | None:
+    tree = ET.parse(svg_file)
+    root = tree.getroot()
+    for circle in root.findall(".//svg:circle", NS):
+        if circle.attrib.get("stroke") == "red":
+            cx = float(circle.attrib["cx"])
+            cy = float(circle.attrib["cy"])
+            return cx, cy
+    return None
+
+
+def test_mark_shape_and_position_inherited(cylinder_stl, tmp_path):
+    random.seed(0)
+    out_dir = tmp_path / "svgs"
+    process_model(
+        stl_file=str(cylinder_stl),
+        layer_height=2.5,
+        output_folder=str(out_dir),
+    )
+
+    files = sorted(out_dir.glob("slice_*.svg"))
+    assert files, "no svg files generated"
+
+    positions = [pos for pos in (_circle_position(str(f)) for f in files) if pos]
+    # There should be at least two slices with marks to compare
+    assert len(positions) >= 2
+
+    first = positions[0]
+    for pos in positions[1:]:
+        assert pos == first


### PR DESCRIPTION
## Summary
- add fixture to generate a deterministic cylinder STL
- test that reference marks keep their shape and position across slices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684909a03ed88333a3f54bd1934e182f