### PR TITLE
Document mark parameter effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ The CLI exposes parameters for tuning reference mark generation:
 - `--mark-angle` – default orientation angle for generated marks in degrees.
 - `--mark-color` – outline color for reference marks.
 
-See [docs/configuration.md](docs/configuration.md) for full details on how these
-options influence mark placement.
+See [docs/reference_mark_algorithm.md#parameter-effects](docs/reference_mark_algorithm.md#parameter-effects)
+for diagrams and tuning tips on how these options influence mark placement.
 
 ## Contributing
 

--- a/docs/reference_mark_algorithm.md
+++ b/docs/reference_mark_algorithm.md
@@ -64,3 +64,63 @@ class ReferenceMarkAdjuster:
 The final mark set thus respects minimum distances while preserving inherited
 shapes whenever possible.
 
+## Parameter Effects
+
+The parameters controlling mark placement can be tuned to suit different model
+sizes. The following diagrams illustrate how each option influences the final
+reference marks.
+
+### `tolerance`
+
+Marks from a previous slice are reused when they fall within the tolerance
+radius of a candidate position.
+
+```mermaid
+flowchart LR
+    A((Stored mark)) -- within tolerance --> B[Reuse]
+    A -- beyond tolerance --> C[New mark]
+```
+
+### `min_distance`
+
+Marks must stay at least this far from contours **and** other marks.
+
+```mermaid
+flowchart LR
+    C[Contour]
+    M1((Mark1)) -- min_distance --> C
+    M1 ---|min_distance| M2((Mark2))
+```
+
+### `available_shapes`
+
+When a new mark is required the shapes are cycled in order.
+
+```mermaid
+flowchart LR
+    S1[Circle] --> S2[Square] --> S3[Triangle] --> S4[Arrow] --> S1
+```
+
+### `angle`
+
+Controls the orientation of newly generated marks.
+
+```mermaid
+flowchart LR
+    A[Default orientation] -- angle --> B[Rotated]
+```
+
+### `color`
+
+Sets the stroke color used when drawing marks. It does not affect placement but
+may improve visibility in the output SVGs.
+
+#### Tips for Different Model Scales
+
+- **Small models (<10&nbsp;cm)** – use a `min_distance` around 2&ndash;5 units and
+  a lower `tolerance` to prevent clutter.
+- **Medium models (10&ndash;30&nbsp;cm)** – the defaults (10 units) usually work
+  well.
+- **Large models (>30&nbsp;cm)** – increase both `min_distance` and `tolerance`
+  proportionally (15&ndash;25 units) so marks remain distinct.
+

--- a/layerforge/cli.py
+++ b/layerforge/cli.py
@@ -89,11 +89,39 @@ def process_model(
 @click.option('--output-folder', default='output', help='The output folder for SVG files.')
 @click.option('--scale-factor', default=None, type=float, help='The scale factor to apply to the model.')
 @click.option('--target-height', default=None, type=float, help='The target height for the model.')
-@click.option('--mark-tolerance', default=10.0, type=float, help='Tolerance when matching existing marks.')
-@click.option('--mark-min-distance', default=10.0, type=float, help='Minimum distance from contours and between marks.')
-@click.option('--available-shapes', default='circle,square,triangle,arrow', help='Comma separated list of mark shapes.')
-@click.option('--mark-angle', default=0.0, type=float, help='Default mark orientation in degrees.')
-@click.option('--mark-color', default=None, help='Outline color for marks.')
+@click.option(
+    '--mark-tolerance',
+    default=10.0,
+    type=float,
+    help='Tolerance when matching existing marks. '
+    'See docs/reference_mark_algorithm.md#parameter-effects.'
+)
+@click.option(
+    '--mark-min-distance',
+    default=10.0,
+    type=float,
+    help='Minimum distance from contours and between marks. '
+    'See docs/reference_mark_algorithm.md#parameter-effects.'
+)
+@click.option(
+    '--available-shapes',
+    default='circle,square,triangle,arrow',
+    help='Comma separated list of mark shapes. '
+    'See docs/reference_mark_algorithm.md#parameter-effects.'
+)
+@click.option(
+    '--mark-angle',
+    default=0.0,
+    type=float,
+    help='Default mark orientation in degrees. '
+    'See docs/reference_mark_algorithm.md#parameter-effects.'
+)
+@click.option(
+    '--mark-color',
+    default=None,
+    help='Outline color for marks. '
+    'See docs/reference_mark_algorithm.md#parameter-effects.'
+)
 def cli(
     stl_file: str,
     layer_height: float,


### PR DESCRIPTION
## Summary
- expand docs with diagrams showing how mark parameters affect placement
- add tuning tips for various model scales
- link new section from README and CLI help text

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490aa1a2d48333850e4f18640c8a24