### PR TITLE
Document PyOxidizer build steps

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -83,3 +83,31 @@ The test suite depends on optional libraries such as `shapely` and `trimesh`. Ea
 test module calls `pytest.importorskip` for these imports so that tests are
 skipped if the dependencies are unavailable. Install these packages to execute
 the entire suite.
+
+## Building a Standalone Executable
+
+LayerForge uses [PyOxidizer](https://github.com/indygreg/PyOxidizer) to bundle the application and its dependencies into a single binary. As mentioned in the [README](../README.md#features), "Pyoxidizer packaging enables simple cross-platform distribution."
+
+### Requirements
+
+- Rust toolchain (\`cargo\` and \`rustc\`)
+- Python 3.12 or newer
+- PyOxidizer installed via `pip install pyoxidizer`
+- Supported on Linux and Windows
+
+### Build Steps
+
+Run the following from the project root:
+
+```bash
+pyoxidizer build
+```
+
+The resulting executable will be placed under `build/`.
+
+### Troubleshooting
+
+- **Missing Rust toolchain**: install Rust from [rustup.rs](https://rustup.rs) and ensure `cargo` is on your `PATH`.
+- **Incorrect Python version**: PyOxidizer must use Python 3.12+. Set `PYTHON_SYS_EXECUTABLE` if multiple versions are installed.
+- **Windows build errors**: run from a Developer Command Prompt so that MSVC tools are available.
+- **Anti-virus interference**: some security tools may quarantine the generated binary. Whitelist the output directory if needed.


### PR DESCRIPTION
## Summary
- document how to build a standalone binary with PyOxidizer
- include troubleshooting and platform notes

## Testing
- `pip install -r requirements-dev.txt`
- `pip install scipy`
- `pip install networkx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68490aab09e083338f8a9bd993abe36b