### PR TITLE
Enhance configuration and add property tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ A 3D Model Slicing and SVG Generation Application
    pip install -e .
    ```
    Alternatively, run `pip install -r requirements.txt` if you only need the runtime dependencies.
+   To ensure all optional features are available use:
+   ```bash
+   pip install -e .[full]
+   ```
 5. Install development dependencies for running the tests:
    ```bash
    pip install -r requirements-dev.txt

--- a/layerforge/models/model.py
+++ b/layerforge/models/model.py
@@ -62,9 +62,14 @@ class Model:
         """
         plane_normal = [0, 0, 1]
         plane_origin = [0, 0, position]
-        layer = self.mesh.section(plane_origin=plane_origin, plane_normal=plane_normal)
+        layer = self.mesh.section(
+            plane_origin=plane_origin, plane_normal=plane_normal
+        )
         if layer is not None:
-            slice_2d, _ = layer.to_planar()
+            if hasattr(layer, "to_2D"):
+                slice_2d = layer.to_2D()
+            else:
+                slice_2d, _ = layer.to_planar()
             contours = slice_2d.polygons_closed
             return [Polygon(contour) for contour in contours]
         return []

--- a/layerforge/models/reference_marks/config.py
+++ b/layerforge/models/reference_marks/config.py
@@ -1,14 +1,31 @@
-from dataclasses import dataclass, field
-from typing import List
+from __future__ import annotations
 
-@dataclass
-class ReferenceMarkConfig:
+from typing import List
+from pydantic import BaseModel, Field, field_validator
+
+
+class ReferenceMarkConfig(BaseModel):
     """Configuration options for reference marks."""
 
     tolerance: float = 10.0
     min_distance: float = 10.0
-    available_shapes: List[str] = field(
+    available_shapes: List[str] = Field(
         default_factory=lambda: ["circle", "square", "triangle", "arrow"]
     )
     angle: float = 0.0
     color: str | None = None
+
+    @field_validator("available_shapes")
+    @classmethod
+    def _validate_shapes(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise ValueError("available_shapes must not be empty")
+        return v
+
+    @field_validator("tolerance", "min_distance")
+    @classmethod
+    def _non_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("values must be non-negative")
+        return v
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,19 @@ scipy = "^1.14"
 shapely = "^2.0"
 svgwrite = "^1.4"
 trimesh = "^4.4"
+pydantic = "^2.6"
 
+[tool.poetry.extras]
+full = [
+    "Rtree",
+    "networkx",
+    "numpy",
+    "scipy",
+    "shapely",
+    "svgwrite",
+    "trimesh",
+    "pydantic",
+]
 [tool.poetry.group.docs]
 optional = true
 
@@ -30,9 +42,16 @@ mkdocs-click = "*"
 mkdocs-literate-nav = "*"
 mkdocs-section-index = "*"
 
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+hypothesis = "*"
+
 [tool.poetry.scripts]
 layerforge = "layerforge.cli:cli"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
+hypothesis
 svgwrite==1.4.3
 shapely==2.0.4
 trimesh==4.4.1

--- a/tests/test_reference_mark_property.py
+++ b/tests/test_reference_mark_property.py
@@ -1,0 +1,38 @@
+import random
+
+import pytest
+from hypothesis import given, strategies as st, assume
+from shapely.geometry import Polygon, Point
+
+from layerforge.models.reference_marks import (
+    ReferenceMarkCalculator,
+    ReferenceMarkManager,
+    ReferenceMarkConfig,
+)
+from layerforge.models.slicing.slice import Slice
+from layerforge.utils import calculate_distance
+
+
+@given(st.lists(st.tuples(st.floats(0, 100), st.floats(0, 100)), min_size=3, max_size=6))
+def test_marks_inside_polygon(coords):
+    poly = Polygon(coords).convex_hull
+    assume(poly.area > 0)
+    cfg = ReferenceMarkConfig(min_distance=1)
+    manager = ReferenceMarkManager(config=cfg)
+    sl = Slice(0, 0.0, [poly], origin=(0, 0), mark_manager=manager, config=cfg)
+    marks = ReferenceMarkCalculator.get_stable_marks(sl, [], config=cfg)
+    for x, y in marks:
+        pt = Point(x, y)
+        assert poly.contains(pt)
+        assert poly.boundary.distance(pt) >= cfg.min_distance
+    for i, m1 in enumerate(marks):
+        for m2 in marks[i+1:]:
+            assert calculate_distance(m1[0], m1[1], m2[0], m2[1]) >= cfg.min_distance
+
+
+def test_stability_score_permutation():
+    pts = [(0, 0), (10, 0), (0, 10)]
+    score = ReferenceMarkCalculator._stability_score(pts)
+    random.shuffle(pts)
+    assert score == pytest.approx(ReferenceMarkCalculator._stability_score(pts))
+


### PR DESCRIPTION
## Summary
- add `[full]` install extras in pyproject
- switch `Model.calculate_slice_contours` to use `to_2D` when available
- validate `ReferenceMarkConfig` using pydantic
- include Hypothesis for dev and add property-based tests
- mention optional extras in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849102f14dc8333a492fb64a2b962b0