### PR TITLE
Improve type hints and mypy settings

### DIFF
--- a/layerforge/__init__.py
+++ b/layerforge/__init__.py
@@ -19,7 +19,7 @@ def _load_version() -> str:
         try:
             with pyproject.open("rb") as f:
                 data = tomllib.load(f)
-            return data["tool"]["poetry"]["version"]
+            return str(data["tool"]["poetry"]["version"])
         except Exception:
             pass
     try:

--- a/layerforge/domain/shapes/triangle.py
+++ b/layerforge/domain/shapes/triangle.py
@@ -18,7 +18,7 @@ class Triangle(BaseShape):
         return 'triangle'
 
     @property
-    def vertices(self) -> list:
+    def vertices(self) -> list[tuple[float, float]]:
         """Return the vertices of the triangle.
 
         Returns

--- a/layerforge/models/model.py
+++ b/layerforge/models/model.py
@@ -1,12 +1,12 @@
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, TypeAlias, Sequence, cast
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover
     from shapely.geometry import Polygon as ShpPolygon
-    Polygon = ShpPolygon
+    Polygon: TypeAlias = ShpPolygon
 else:
-    Polygon = require_module("shapely.geometry", "Model").Polygon
+    Polygon: TypeAlias = require_module("shapely.geometry", "Model").Polygon
 from .loading.mesh import Mesh
 
 
@@ -47,8 +47,8 @@ class Model:
         float
             The height of the model.
         """
-        min_bound, max_bound = self.mesh.bounds
-        height = max_bound[2] - min_bound[2]
+        min_bound, max_bound = cast(tuple[Sequence[float], Sequence[float]], self.mesh.bounds)
+        height = float(max_bound[2] - min_bound[2])
         return height
 
     def calculate_slice_contours(self, position: float) -> list[Polygon]:

--- a/layerforge/models/reference_marks/reference_mark_adjuster.py
+++ b/layerforge/models/reference_marks/reference_mark_adjuster.py
@@ -1,15 +1,15 @@
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover
     from shapely.geometry import Point as ShpPoint, Polygon as ShpPolygon
-    Point = ShpPoint
-    Polygon = ShpPolygon
+    Point: TypeAlias = ShpPoint
+    Polygon: TypeAlias = ShpPolygon
 else:
     _shapely = require_module("shapely.geometry", "ReferenceMarkAdjuster")
-    Point = _shapely.Point
-    Polygon = _shapely.Polygon
+    Point: TypeAlias = _shapely.Point
+    Polygon: TypeAlias = _shapely.Polygon
 
 from .reference_mark import ReferenceMark
 from .config import ReferenceMarkConfig

--- a/layerforge/models/reference_marks/reference_mark_calculator.py
+++ b/layerforge/models/reference_marks/reference_mark_calculator.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List, Tuple, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:
     from shapely.geometry import Point as ShpPoint, Polygon as ShpPolygon
-    Point = ShpPoint
-    Polygon = ShpPolygon
+    Point: TypeAlias = ShpPoint
+    Polygon: TypeAlias = ShpPolygon
 else:
     _shapely = require_module("shapely.geometry", "ReferenceMarkCalculator")
-    Point = _shapely.Point
-    Polygon = _shapely.Polygon
+    Point: TypeAlias = _shapely.Point
+    Polygon: TypeAlias = _shapely.Polygon
 import random
 
 from layerforge.utils import calculate_distance

--- a/layerforge/models/reference_marks/reference_mark_manager.py
+++ b/layerforge/models/reference_marks/reference_mark_manager.py
@@ -1,15 +1,15 @@
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover
     from shapely.geometry import Point as ShpPoint, Polygon as ShpPolygon
-    Point = ShpPoint
-    Polygon = ShpPolygon
+    Point: TypeAlias = ShpPoint
+    Polygon: TypeAlias = ShpPolygon
 else:
     _shapely = require_module("shapely.geometry", "ReferenceMarkManager")
-    Point = _shapely.Point
-    Polygon = _shapely.Polygon
+    Point: TypeAlias = _shapely.Point
+    Polygon: TypeAlias = _shapely.Polygon
 
 from .config import ReferenceMarkConfig
 

--- a/layerforge/models/slicing/slice.py
+++ b/layerforge/models/slicing/slice.py
@@ -1,13 +1,13 @@
 import logging
-from typing import List, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover
     from shapely.geometry import Polygon as ShpPolygon
-    Polygon = ShpPolygon
+    Polygon: TypeAlias = ShpPolygon
 else:
-    Polygon = require_module("shapely.geometry", "Slice").Polygon
+    Polygon: TypeAlias = require_module("shapely.geometry", "Slice").Polygon
 
 from layerforge.models.reference_marks import (
     ReferenceMark,

--- a/layerforge/svg/drawing/shape_factory.py
+++ b/layerforge/svg/drawing/shape_factory.py
@@ -2,6 +2,7 @@
 
 from layerforge.domain.shapes import Arrow, Circle, Square, Triangle
 from layerforge.domain.shapes.base_shape import BaseShape
+from typing import Any, cast
 
 # Registry mapping shape names to their implementing classes
 _SHAPE_REGISTRY: dict[str, type[BaseShape]] = {
@@ -12,7 +13,7 @@ _SHAPE_REGISTRY: dict[str, type[BaseShape]] = {
 }
 
 
-def register_shape(name: str, cls: type) -> None:
+def register_shape(name: str, cls: type[BaseShape]) -> None:
     """Register ``cls`` under ``name`` in the factory registry."""
     _SHAPE_REGISTRY[name] = cls
 
@@ -20,7 +21,9 @@ def register_shape(name: str, cls: type) -> None:
 class ShapeFactory:
     """Factory class for creating shapes."""
     @staticmethod
-    def get_shape(shape_type: str, *args, **kwargs) -> BaseShape:
+    def get_shape(
+        shape_type: str, *args: object, **kwargs: object
+    ) -> BaseShape:
         """Return an instance of the shape registered under ``shape_type``.
 
         Raises
@@ -35,4 +38,4 @@ class ShapeFactory:
             raise ValueError(
                 f"Unknown shape type: {shape_type}. Available shapes: {available}"
             )
-        return shape_cls(*args, **kwargs)
+        return cast(BaseShape, cast(Any, shape_cls)(*args, **kwargs))

--- a/layerforge/svg/drawing/strategies/arrow_strategy.py
+++ b/layerforge/svg/drawing/strategies/arrow_strategy.py
@@ -1,30 +1,26 @@
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
+    Drawing: TypeAlias = SvgDrawing
 else:
-    Drawing = require_module("svgwrite", "ArrowDrawingStrategy").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "ArrowDrawingStrategy").Drawing  # type: ignore
 
 from layerforge.domain.shapes import Arrow
+from layerforge.domain.shapes.base_shape import BaseShape
 from .base_strategy import ShapeDrawingStrategy
+from typing import cast
 
 
 class ArrowDrawingStrategy(ShapeDrawingStrategy):
     """Drawing strategy for Arrow shapes."""
 
-    def draw(self, dwg: Drawing, arrow: Arrow) -> None:
-        """Draws an Arrow shape on the given Drawing object.
-
-        Parameters
-        ----------
-        dwg : Drawing
-            The Drawing object to draw the shape on.
-        arrow : Arrow
-            The Arrow shape to draw.
-        """
+    def draw(self, dwg: Drawing, shape: BaseShape) -> None:
+        """Draw an :class:`Arrow` shape on ``dwg``."""
+        arrow = cast(Arrow, shape)
         angle = arrow.angle
         if abs(angle) > 2 * math.pi:
             angle = math.radians(angle)

--- a/layerforge/svg/drawing/strategies/base_strategy.py
+++ b/layerforge/svg/drawing/strategies/base_strategy.py
@@ -1,13 +1,14 @@
 from abc import ABC, abstractmethod
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover - import only for type checking
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
+    Drawing: TypeAlias = SvgDrawing
 else:  # pragma: no cover - imported lazily for runtime
-    Drawing = require_module("svgwrite", "ShapeDrawingStrategy").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "ShapeDrawingStrategy").Drawing  # type: ignore
 
 from layerforge.domain.shapes.base_shape import BaseShape
 

--- a/layerforge/svg/drawing/strategies/circle_strategy.py
+++ b/layerforge/svg/drawing/strategies/circle_strategy.py
@@ -1,34 +1,26 @@
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
+    Drawing: TypeAlias = SvgDrawing
 else:
-    Drawing = require_module("svgwrite", "CircleDrawingStrategy").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "CircleDrawingStrategy").Drawing  # type: ignore
 
 from layerforge.domain.shapes import Circle
+from layerforge.domain.shapes.base_shape import BaseShape
 from .base_strategy import ShapeDrawingStrategy
+from typing import cast
 
 
 class CircleDrawingStrategy(ShapeDrawingStrategy):
     """Drawing strategy for Circle shapes."""
 
-    def draw(self, dwg: Drawing, circle: Circle) -> None:
-        """Draws a Circle shape on the given Drawing object.
-
-        Parameters
-        ----------
-        dwg : Drawing
-            The Drawing object to draw the shape on.
-        circle : Circle
-            The Circle shape to draw.
-
-        Returns
-        -------
-        None
-        """
+    def draw(self, dwg: Drawing, shape: BaseShape) -> None:
+        """Draw a :class:`Circle` shape on ``dwg``."""
+        circle = cast(Circle, shape)
         color = circle.color or 'red'
         # rotation has no visible effect for circles but is kept for consistency
         element = dwg.circle(

--- a/layerforge/svg/drawing/strategies/square_strategy.py
+++ b/layerforge/svg/drawing/strategies/square_strategy.py
@@ -1,34 +1,26 @@
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
+    Drawing: TypeAlias = SvgDrawing
 else:
-    Drawing = require_module("svgwrite", "SquareDrawingStrategy").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "SquareDrawingStrategy").Drawing  # type: ignore
 
 from layerforge.domain.shapes import Square
+from layerforge.domain.shapes.base_shape import BaseShape
 from .base_strategy import ShapeDrawingStrategy
+from typing import cast
 
 
 class SquareDrawingStrategy(ShapeDrawingStrategy):
     """Drawing strategy for Square shapes."""
 
-    def draw(self, dwg: Drawing, square: Square) -> None:
-        """Draws a Square shape on the given Drawing object.
-
-        Parameters
-        ----------
-        dwg : Drawing
-            The Drawing object to draw the shape on.
-        square : Square
-            The Square shape to draw.
-
-        Returns
-        -------
-        None
-        """
+    def draw(self, dwg: Drawing, shape: BaseShape) -> None:
+        """Draw a :class:`Square` shape on ``dwg``."""
+        square = cast(Square, shape)
         color = square.color or 'blue'
         element = dwg.rect(
             insert=(square.x - square.size / 2, square.y - square.size / 2),

--- a/layerforge/svg/drawing/strategies/triangle_strategy.py
+++ b/layerforge/svg/drawing/strategies/triangle_strategy.py
@@ -1,34 +1,26 @@
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
+    Drawing: TypeAlias = SvgDrawing
 else:
-    Drawing = require_module("svgwrite", "TriangleDrawingStrategy").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "TriangleDrawingStrategy").Drawing  # type: ignore
 
 from layerforge.domain.shapes import Triangle
+from layerforge.domain.shapes.base_shape import BaseShape
 from .base_strategy import ShapeDrawingStrategy
+from typing import cast
 
 
 class TriangleDrawingStrategy(ShapeDrawingStrategy):
     """Drawing strategy for Triangle shapes."""
 
-    def draw(self, dwg: Drawing, triangle: Triangle) -> None:
-        """Draws a Triangle shape on the given Drawing object.
-
-        Parameters
-        ----------
-        dwg : Drawing
-            The Drawing object to draw the shape on.
-        triangle : Triangle
-            The Triangle shape to draw.
-
-        Returns
-        -------
-        None
-        """
+    def draw(self, dwg: Drawing, shape: BaseShape) -> None:
+        """Draw a :class:`Triangle` shape on ``dwg``."""
+        triangle = cast(Triangle, shape)
         color = triangle.color or 'green'
         verts = triangle.vertices
         if triangle.angle:

--- a/layerforge/svg/drawing/strategy_context.py
+++ b/layerforge/svg/drawing/strategy_context.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
     from .strategies.base_strategy import ShapeDrawingStrategy
+    Drawing: TypeAlias = SvgDrawing
 else:
     from layerforge.utils.optional_dependencies import require_module
-    Drawing = require_module("svgwrite", "StrategyContext").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "StrategyContext").Drawing  # type: ignore
 from layerforge.domain.shapes.base_shape import BaseShape
 
 
@@ -20,8 +21,8 @@ class StrategyContext:
         A dictionary of strategies with shape type as key and strategy as value.
     """
 
-    def __init__(self):
-        self._strategies = {}
+    def __init__(self) -> None:
+        self._strategies: dict[str, ShapeDrawingStrategy] = {}
 
     def register_strategy(self, shape_type: str, strategy: ShapeDrawingStrategy) -> None:
         """Registers a drawing strategy for a specific shape type.

--- a/layerforge/svg/slice_svg_drawer.py
+++ b/layerforge/svg/slice_svg_drawer.py
@@ -1,19 +1,19 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from shapely.geometry import Point as ShpPoint, Polygon as ShpPolygon
     from svgwrite import Drawing as SvgDrawing
-    Point = ShpPoint
-    Polygon = ShpPolygon
-    Drawing = SvgDrawing
+    Point: TypeAlias = ShpPoint
+    Polygon: TypeAlias = ShpPolygon
+    Drawing: TypeAlias = SvgDrawing
 else:  # pragma: no cover - lazy imports
     _shapely = require_module("shapely.geometry", "SliceSVGDrawer")
     _svgwrite = require_module("svgwrite", "SliceSVGDrawer")
-    Point = _shapely.Point
-    Polygon = _shapely.Polygon
-    Drawing = _svgwrite.Drawing
+    Point: TypeAlias = _shapely.Point
+    Polygon: TypeAlias = _shapely.Polygon
+    Drawing: TypeAlias = _svgwrite.Drawing
 
 from layerforge.models.slicing import Slice
 from layerforge.models.reference_marks import ReferenceMark

--- a/layerforge/utils/geometry.py
+++ b/layerforge/utils/geometry.py
@@ -17,4 +17,4 @@ def calculate_distance(x1: float, y1: float, x2: float, y2: float) -> float:
     float
         The distance between the two points.
     """
-    return ((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5
+    return float(((x2 - x1) ** 2 + (y2 - y1) ** 2) ** 0.5)

--- a/layerforge/writers/svg_writer.py
+++ b/layerforge/writers/svg_writer.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from layerforge.utils.optional_dependencies import require_module
 
 if TYPE_CHECKING:  # pragma: no cover - import only for type checking
-    from svgwrite import Drawing
+    from svgwrite import Drawing as SvgDrawing
+    Drawing: TypeAlias = SvgDrawing
 else:  # pragma: no cover - imported lazily for runtime
-    Drawing = require_module("svgwrite", "SVGWriter").Drawing  # type: ignore
+    Drawing: TypeAlias = require_module("svgwrite", "SVGWriter").Drawing  # type: ignore
 
 from layerforge.utils.file_operations import ensure_directory_exists, generate_file_name
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+python_version = 3.12
+strict = True
+ignore_missing_imports = True
+allow_subclassing_any = True
+allow_untyped_decorators = True
+implicit_reexport = True
+files = layerforge/writers/svg_writer.py, layerforge/svg/drawing, layerforge/models


### PR DESCRIPTION
## Summary
- enable strict mypy checking via a new `mypy.ini`
- annotate writers and svg drawing modules
- tighten model and reference mark types
- fix geometry helper typing
- ensure mypy passes with no issues

## Testing
- `mypy --config-file mypy.ini`

------
https://chatgpt.com/codex/tasks/task_e_6849266d73f88333986e0012a6d9859e