### PR TITLE
Add ReferenceMarkConfig validation tests

### DIFF
--- a/tests/test_reference_mark_config.py
+++ b/tests/test_reference_mark_config.py
@@ -1,0 +1,14 @@
+import pytest
+
+from layerforge.models.reference_marks import ReferenceMarkConfig
+
+
+def test_empty_available_shapes_raises():
+    with pytest.raises(ValueError):
+        ReferenceMarkConfig(available_shapes=[])
+
+
+@pytest.mark.parametrize("field", ["tolerance", "min_distance"])
+def test_negative_values_raise_value_error(field):
+    with pytest.raises(ValueError):
+        ReferenceMarkConfig(**{field: -1})


### PR DESCRIPTION
## Summary
- test empty `available_shapes` raises a ValueError
- test negative `tolerance` and `min_distance` raise a ValueError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849294c80148333b4fb51a2348c9532