### PR TITLE
Add CLI tests

### DIFF
--- a/layerforge/models/reference_marks/reference_mark_calculator.py
+++ b/layerforge/models/reference_marks/reference_mark_calculator.py
@@ -47,6 +47,10 @@ class ReferenceMarkCalculator:
         sampled within the bounding box until ``samples`` unique points that are
         contained within ``poly`` are found.
         """
+        if not poly.is_valid:
+            rounded = [(round(x, 6), round(y, 6)) for x, y in poly.exterior.coords]
+            poly = Polygon(rounded).buffer(0)
+
         pts = [(poly.centroid.x, poly.centroid.y)]
         minx, miny, maxx, maxy = poly.bounds
 
@@ -60,7 +64,11 @@ class ReferenceMarkCalculator:
             x = random.uniform(minx, maxx)
             y = random.uniform(miny, maxy)
             candidate = Point(x, y)
-            if poly.contains(candidate):
+            try:
+                inside = poly.contains(candidate)
+            except Exception:
+                inside = False
+            if inside:
                 cand_tuple = (candidate.x, candidate.y)
                 if cand_tuple not in pts:
                     pts.append(cand_tuple)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 from click.testing import CliRunner
+import pytest
 
 from layerforge import cli as cli_module
 cli = cli_module.cli
@@ -58,3 +59,57 @@ def test_cli_conflicting_options(monkeypatch):
 
     assert result.exit_code == 1
     assert "Only one of scale_factor or target_height can be provided." in result.output
+
+
+def test_cli_invalid_options_error(cylinder_stl, tmp_path):
+    """Invoking with both scaling options should produce an error."""
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "--stl-file",
+            str(cylinder_stl),
+            "--layer-height",
+            "0.5",
+            "--output-folder",
+            str(tmp_path),
+            "--scale-factor",
+            "1.0",
+            "--target-height",
+            "10.0",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Only one of scale_factor or target_height can be provided." in result.output
+
+
+def test_cli_end_to_end_generates_svgs(tmp_path):
+    """A full CLI run should generate SVG slices."""
+    pytest.importorskip("trimesh")
+    pytest.importorskip("svgwrite")
+    pytest.importorskip("shapely")
+
+    import trimesh
+
+    mesh = trimesh.creation.box(extents=(20, 20, 20))
+    stl_path = tmp_path / "model.stl"
+    mesh.export(stl_path)
+
+    out_dir = tmp_path / "svgs"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--stl-file",
+            str(stl_path),
+            "--layer-height",
+            "5.0",
+            "--output-folder",
+            str(out_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sorted(out_dir.glob("slice_*.svg")), "no svg files generated"


### PR DESCRIPTION
## Summary
- expand CLI tests for invalid options
- test complete CLI run using a temporary STL
- harden reference mark calculation for degenerate polygons

## Testing
- `pytest -q` *(fails: Hypothesis found 2 distinct failures)*

------
https://chatgpt.com/codex/tasks/task_e_68499e3bbca48333841b053c97460bba