### PR TITLE
Add tests for file operations utilities

### DIFF
--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1,0 +1,14 @@
+import os
+from layerforge.utils.file_operations import ensure_directory_exists, generate_file_name
+
+
+def test_ensure_directory_exists_creates_tmp_dir(tmp_path):
+    dir_path = tmp_path / "created"
+    assert not dir_path.exists()
+    ensure_directory_exists(str(dir_path))
+    assert dir_path.exists() and dir_path.is_dir()
+
+
+def test_generate_file_name_formatting():
+    result = generate_file_name("dir", 1, "svg")
+    assert result == "dir/slice_001.svg"


### PR DESCRIPTION
## Summary
- cover `ensure_directory_exists` and `generate_file_name` with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a26119f8833394843747d7a2ea6e