### PR TITLE
Preserve angle and color in reference marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ python -c "import layerforge; print(layerforge.__version__)"
 - Slice STL models into individual layers.
 - Generate SVG files with contours, slice numbers and reference marks.
 - Reference marks are chosen using a geometric stability metric inspired by GDOP.
-- Marks inherit shape and position between adjacent slices and are adjusted to avoid overlaps.
+- Marks inherit shape, position, angle and color between adjacent slices and are adjusted to avoid overlaps.
 - Supports multiple mark shapes (circle, square, triangle, arrow) for easy identification.
 - Pyoxidizer packaging enables simple cross-platform distribution.
 

--- a/docs/reference_mark_algorithm.md
+++ b/docs/reference_mark_algorithm.md
@@ -30,8 +30,8 @@ first; otherwise the best scoring candidate is selected.
 
 When processing a slice, the algorithm checks whether any stored mark lies inside
 a contour at a safe distance from the edges. If so, that mark is reused and keeps
-its original shape. This inheritance gives each layer a shared set of identifiers
-for accurate reassembly.
+its original shape **as well as its orientation angle and stroke color**. This
+inheritance gives each layer a shared set of identifiers for accurate reassembly.
 
 ```mermaid
 flowchart TD

--- a/layerforge/models/reference_marks/reference_mark_manager.py
+++ b/layerforge/models/reference_marks/reference_mark_manager.py
@@ -48,6 +48,8 @@ class ReferenceMarkManager:
         if mark:
             mark.shape = shape
             mark.size = size
+            mark.angle = angle
+            mark.color = color
         else:
             self.marks.append(
                 ReferenceMark(x=x, y=y, shape=shape, size=size, angle=angle, color=color)

--- a/layerforge/models/slicing/slice.py
+++ b/layerforge/models/slicing/slice.py
@@ -97,8 +97,8 @@ class Slice:
                         y=y,
                         shape=existing_mark.shape,
                         size=existing_mark.size,
-                        angle=self.config.angle,
-                        color=self.config.color,
+                        angle=existing_mark.angle,
+                        color=existing_mark.color,
                     )
                 )
             else:

--- a/tests/test_reference_mark_manager.py
+++ b/tests/test_reference_mark_manager.py
@@ -6,16 +6,20 @@ from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMar
 
 def test_add_and_update_mark():
     manager = ReferenceMarkManager()
-    manager.add_or_update_mark(10, 20, "circle", 3)
+    manager.add_or_update_mark(10, 20, "circle", 3, angle=45, color="red")
     assert len(manager.marks) == 1
     assert manager.marks[0].shape == "circle"
     assert manager.marks[0].size == 3
+    assert manager.marks[0].angle == 45
+    assert manager.marks[0].color == "red"
 
     # update existing position
-    manager.add_or_update_mark(10, 20, "square", 5)
+    manager.add_or_update_mark(10, 20, "square", 5, angle=90, color="blue")
     assert len(manager.marks) == 1
     assert manager.marks[0].shape == "square"
     assert manager.marks[0].size == 5
+    assert manager.marks[0].angle == 90
+    assert manager.marks[0].color == "blue"
 
     # add new mark at different position
     manager.add_or_update_mark(30, 40, "triangle", 4)

--- a/tests/test_slice_process_reference_marks.py
+++ b/tests/test_slice_process_reference_marks.py
@@ -21,3 +21,21 @@ def test_new_mark_added_to_manager():
     assert len(manager.marks) == 1
     assert manager.marks[0].x == sl.ref_marks[0].x
     assert manager.marks[0].y == sl.ref_marks[0].y
+
+
+def test_inherited_mark_keeps_angle_and_color():
+    square = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    manager = ReferenceMarkManager()
+    cfg1 = ReferenceMarkConfig(min_distance=10, angle=45, color="red")
+    sl1 = Slice(0, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg1)
+    ReferenceMarkService.process_slice(sl1)
+    assert sl1.ref_marks[0].angle == 45
+    assert sl1.ref_marks[0].color == "red"
+
+    cfg2 = ReferenceMarkConfig(min_distance=10, angle=90, color="blue")
+    sl2 = Slice(1, 0.0, [square], origin=(0, 0), mark_manager=manager, config=cfg2)
+    ReferenceMarkService.process_slice(sl2)
+    assert sl2.ref_marks[0].angle == 45
+    assert sl2.ref_marks[0].color == "red"
+    assert manager.marks[0].angle == 45
+    assert manager.marks[0].color == "red"


### PR DESCRIPTION
## Summary
- copy angle and color when inheriting reference marks
- allow updating angle and color in `ReferenceMarkManager`
- document how orientation and stroke color are inherited
- mention in README
- test angle and color persistence across slices

## Testing
- `pytest -q` *(fails: AttributeError: 'tuple' object has no attribute 'polygons_closed')*

------
https://chatgpt.com/codex/tasks/task_e_6849b1335bfc8333b5e352a2e89bdfe4