### PR TITLE
Remove unused sys import

### DIFF
--- a/layerforge/cli.py
+++ b/layerforge/cli.py
@@ -1,4 +1,3 @@
-import sys
 import math
 
 


### PR DESCRIPTION
## Summary
- cleanup: drop unused sys import in CLI module

## Testing
- `ruff check layerforge/cli.py`
- `pytest -q` *(fails: TypeError unsupported operand type(s) for |)*

------
https://chatgpt.com/codex/tasks/task_e_6849b586fc08833398bda30b2ca303de