### PR TITLE
Add unit tests for LoaderFactory and mark size calculations

### DIFF
--- a/tests/test_loader_factory.py
+++ b/tests/test_loader_factory.py
@@ -1,0 +1,22 @@
+import pytest
+
+from layerforge.models.loading import LoaderFactory
+from layerforge.models.loading.base import MeshLoader
+
+
+class DummyLoader(MeshLoader):
+    def load_mesh(self, model_file: str):
+        return model_file
+
+
+def test_register_and_get_loader(monkeypatch):
+    monkeypatch.setattr(LoaderFactory, "loaders", {}, raising=False)
+    LoaderFactory.register_loader("dummy", DummyLoader)
+    loader = LoaderFactory.get_loader("dummy")
+    assert isinstance(loader, DummyLoader)
+
+
+def test_get_unknown_loader(monkeypatch):
+    monkeypatch.setattr(LoaderFactory, "loaders", {}, raising=False)
+    with pytest.raises(ValueError):
+        LoaderFactory.get_loader("missing")

--- a/tests/test_slice_mark_size.py
+++ b/tests/test_slice_mark_size.py
@@ -1,0 +1,25 @@
+from layerforge.models.slicing.slice import Slice
+from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkConfig
+
+
+def _make_slice(origin=(0, 0)) -> Slice:
+    manager = ReferenceMarkManager()
+    cfg = ReferenceMarkConfig()
+    return Slice(0, 0.0, [], origin=origin, mark_manager=manager, config=cfg)
+
+
+def test_mark_size_ranges():
+    sl = _make_slice()
+    coords = [
+        (0, 0, 3),
+        (15, 0, 3),
+        (35, 0, 3),
+        (40, 0, 4),
+        (50, 0, 5),
+        (100, 0, 5),
+        (70, 70, 5),
+    ]
+    for x, y, expected in coords:
+        size = sl._calculate_mark_size(x, y)
+        assert 3 <= size <= 5
+        assert size == expected


### PR DESCRIPTION
## Summary
- test LoaderFactory.register_loader and get_loader functionality
- test Slice._calculate_mark_size keeps mark sizes in allowed range

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ba8cb7ac83339c219dc02e9b94fd