### PR TITLE
Add parameter validation for positive values

### DIFF
--- a/layerforge/cli.py
+++ b/layerforge/cli.py
@@ -65,6 +65,13 @@ def process_model(
             "Only one of scale_factor or target_height can be provided."
         )
 
+    if layer_height <= 0:
+        raise click.BadParameter("must be > 0", param_hint="--layer-height")
+    if scale_factor is not None and scale_factor <= 0:
+        raise click.BadParameter("must be > 0", param_hint="--scale-factor")
+    if target_height is not None and target_height <= 0:
+        raise click.BadParameter("must be > 0", param_hint="--target-height")
+
     shape_context = StrategyContext()
     register_shape_strategies(shape_context)
     initialize_loaders()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -114,3 +114,19 @@ def test_cli_end_to_end_generates_svgs(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert sorted(out_dir.glob("slice_*.svg")), "no svg files generated"
+
+def test_cli_invalid_layer_height(monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--stl-file",
+            "model.stl",
+            "--layer-height",
+            "0",
+            "--output-folder",
+            "out",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for --layer-height" in result.output

--- a/tests/test_process_model_validation.py
+++ b/tests/test_process_model_validation.py
@@ -1,0 +1,34 @@
+import pytest
+import click
+
+from layerforge.cli import process_model
+
+
+def test_process_model_invalid_layer_height(cylinder_stl, tmp_path):
+    with pytest.raises(click.BadParameter):
+        process_model(
+            stl_file=str(cylinder_stl),
+            layer_height=0,
+            output_folder=str(tmp_path),
+        )
+
+
+def test_process_model_invalid_scale_factor(cylinder_stl, tmp_path):
+    with pytest.raises(click.BadParameter):
+        process_model(
+            stl_file=str(cylinder_stl),
+            layer_height=1.0,
+            output_folder=str(tmp_path),
+            scale_factor=0,
+        )
+
+
+def test_process_model_invalid_target_height(cylinder_stl, tmp_path):
+    with pytest.raises(click.BadParameter):
+        process_model(
+            stl_file=str(cylinder_stl),
+            layer_height=1.0,
+            output_folder=str(tmp_path),
+            target_height=0,
+        )
+


### PR DESCRIPTION
## Summary
- validate that `layer_height`, `scale_factor`, and `target_height` are greater than zero
- test CLI error handling on invalid `--layer-height`
- add tests for `process_model` validation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c0c858d4833383fd9ca95ad09713