### PR TITLE
Add require_module tests

### DIFF
--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,15 @@
+import types
+import pytest
+
+from layerforge.utils.optional_dependencies import require_module
+
+
+def test_require_module_success():
+    mod = require_module("math", "Test")
+    assert isinstance(mod, types.ModuleType)
+
+
+def test_require_module_missing():
+    with pytest.raises(ImportError) as exc:
+        require_module("nonexistent_package_xyz", "MyFeature")
+    assert str(exc.value) == "MyFeature requires the 'nonexistent_package_xyz' package. Install it via 'pip install nonexistent_package_xyz'."


### PR DESCRIPTION
## Summary
- test success and error paths for `require_module`

## Testing
- `pip install -q -r requirements-dev.txt`
- `pip install -q pydantic==2.6.0`
- `pip install -q scipy==1.14.0`
- `pip install -q networkx==3.3`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849c42b800c833389d1d584cb1d8647