### PR TITLE
Add loader initialization test

### DIFF
--- a/tests/test_loader_initialization.py
+++ b/tests/test_loader_initialization.py
@@ -1,0 +1,13 @@
+import pytest
+
+pytest.importorskip("trimesh")
+
+from layerforge.utils.loader_initialization import initialize_loaders
+from layerforge.models.loading import LoaderFactory
+from layerforge.models.loading.implementations.trimesh_loader import TrimeshLoader
+
+
+def test_initialize_loaders_registers_trimesh(monkeypatch):
+    monkeypatch.setattr(LoaderFactory, "loaders", {}, raising=False)
+    initialize_loaders()
+    assert LoaderFactory.loaders["trimesh"] is TrimeshLoader


### PR DESCRIPTION
## Summary
- add regression test for initialize_loaders registering the trimesh loader

## Testing
- `pytest -q` *(fails: Skipped: could not import 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_e_6849c7f61bcc8333a7b136f11a8ae9ff