### PR TITLE
Add docs for optional deps and PyOxidizer

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -84,6 +84,28 @@ test module calls `pytest.importorskip` for these imports so that tests are
 skipped if the dependencies are unavailable. Install these packages to execute
 the entire suite.
 
+```
+pip install -r requirements-dev.txt
+```
+
+## Optional Dependencies
+
+In addition to the core requirements, installing `scipy` and `networkx` enables
+advanced slicing features in `trimesh` and prevents common runtime errors.
+
+```bash
+pip install scipy networkx
+```
+
+## Common Error Messages
+
+- `ModuleNotFoundError: No module named 'shapely'` – optional geometry
+  libraries are missing.
+- `ModuleNotFoundError: No module named 'networkx'` – some slicing routines in
+  `trimesh` rely on NetworkX.
+- `pyoxidizer: error: Python interpreter too old` – ensure Python 3.12+ is used
+  when building the executable.
+
 ## Building a Standalone Executable
 
 LayerForge uses [PyOxidizer](https://github.com/indygreg/PyOxidizer) to bundle the application and its dependencies into a single binary. As mentioned in the [README](../README.md#features), "Pyoxidizer packaging enables simple cross-platform distribution."
@@ -104,6 +126,15 @@ pyoxidizer build
 ```
 
 The resulting executable will be placed under `build/`.
+
+For quick testing you can run the generated binary directly:
+
+```bash
+./build/layerforge --help
+```
+
+This produces a self-contained executable that embeds Python and all
+project dependencies.
 
 ### Troubleshooting
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -2,6 +2,20 @@
 
 ## Installation
 
+Install the package directly from the repository:
+
+```bash
+pip install -e .
+```
+
+Some features rely on additional libraries.  To enable the full
+functionality (and to run the test suite) also install the optional
+dependencies:
+
+```bash
+pip install shapely trimesh networkx scipy
+```
+
 ## Usage
 
 1. Place the STL file in the project directory.
@@ -24,3 +38,33 @@ python scripts/simple_mesh_example.py
 
 This generates a basic cube mesh, slices it, and writes SVG files to the
 `example_output/` directory.
+
+## CLI Example
+
+Running the CLI directly mirrors the example script.  Below is an
+illustrative session using a temporary cube mesh:
+
+```text
+$ python -m layerforge.cli --stl-file cube.stl --layer-height 5 --output-folder demo_output
+exit 0
+
+files [demo_output/slice_000.svg, demo_output/slice_001.svg, demo_output/slice_002.svg]
+```
+
+Opening the first SVG shows the slice label and contour:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<svg ...>
+  <polygon fill="none" ... />
+  <text ...>Slice 0</text>
+</svg>
+```
+
+## Common Errors
+
+- `ModuleNotFoundError: No module named 'trimesh'` – install the optional
+  dependencies listed above.
+- `FileNotFoundError: [Errno 2] No such file or directory` – check the
+  provided `--stl-file` path.
+- `ConflictingOptionsError: Only one of scale_factor or target_height can be provided.`


### PR DESCRIPTION
## Summary
- document installing optional dependencies and common errors
- add CLI example output showing generated SVG files
- mention extra details for building with PyOxidizer

## Testing
- `pytest -q` *(fails: test_marks_inside_polygon - shapely.errors.GEOSException)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb5b911883339db52dc33c3ce899