### PR TITLE
Simplify reference mark tests

### DIFF
--- a/tests/test_reference_mark_adjuster.py
+++ b/tests/test_reference_mark_adjuster.py
@@ -2,38 +2,11 @@ import pytest
 pytest.importorskip("shapely")
 from shapely.geometry import Polygon
 
-import importlib.util
-import sys
-import types
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-module_name = "layerforge.models.reference_marks.reference_mark_adjuster"
-spec = importlib.util.spec_from_file_location(
-    module_name, ROOT / "layerforge/models/reference_marks/reference_mark_adjuster.py"
+from layerforge.models.reference_marks import (
+    ReferenceMarkAdjuster,
+    ReferenceMarkConfig,
+    ReferenceMark,
 )
-module = importlib.util.module_from_spec(spec)
-
-pkg_layerforge = types.ModuleType("layerforge")
-pkg_models = types.ModuleType("layerforge.models")
-pkg_ref = types.ModuleType("layerforge.models.reference_marks")
-pkg_ref.__path__ = [str(ROOT / "layerforge/models/reference_marks")]
-sys.modules.setdefault("layerforge", pkg_layerforge)
-sys.modules.setdefault("layerforge.models", pkg_models)
-sys.modules.setdefault("layerforge.models.reference_marks", pkg_ref)
-sys.modules[module_name] = module
-spec.loader.exec_module(module)  # type: ignore
-ReferenceMarkAdjuster = module.ReferenceMarkAdjuster
-ReferenceMark = module.ReferenceMark
-
-module_name_config = "layerforge.models.reference_marks.config"
-spec_config = importlib.util.spec_from_file_location(
-    module_name_config, ROOT / "layerforge/models/reference_marks/config.py"
-)
-module_config = importlib.util.module_from_spec(spec_config)
-sys.modules[module_name_config] = module_config
-spec_config.loader.exec_module(module_config)  # type: ignore
-ReferenceMarkConfig = module_config.ReferenceMarkConfig
 
 
 def test_centroid_inside_kept():

--- a/tests/test_reference_mark_calculator.py
+++ b/tests/test_reference_mark_calculator.py
@@ -1,115 +1,11 @@
-import importlib.util
-import sys
-import types
-from pathlib import Path
-
 import pytest
+
 pytest.importorskip("shapely")
+
 from shapely.geometry import Polygon, Point
 
-ROOT = Path(__file__).resolve().parents[1]
-module_name_slice = "layerforge.models.slicing.slice"
-spec_slice = importlib.util.spec_from_file_location(
-    module_name_slice, ROOT / "layerforge/models/slicing/slice.py"
-)
-module_slice = importlib.util.module_from_spec(spec_slice)
-
-pkg_layerforge = types.ModuleType("layerforge")
-pkg_models = types.ModuleType("layerforge.models")
-pkg_models.__path__ = [str(ROOT / "layerforge/models")]
-import importlib.machinery
-pkg_models.__spec__ = importlib.machinery.ModuleSpec("layerforge.models", None, is_package=True)
-pkg_ref = types.ModuleType("layerforge.models.reference_marks")
-pkg_ref.__path__ = [str(ROOT / "layerforge/models/reference_marks")]
-pkg_ref.__spec__ = importlib.machinery.ModuleSpec("layerforge.models.reference_marks", None, is_package=True)
-pkg_utils = types.ModuleType("layerforge.utils")
-pkg_utils.__path__ = [str(ROOT / "layerforge/utils")]
-
-sys.modules["layerforge"] = pkg_layerforge
-sys.modules["layerforge.models"] = pkg_models
-sys.modules["layerforge.models.reference_marks"] = pkg_ref
-sys.modules["layerforge.utils"] = pkg_utils
-module_name_geom = "layerforge.utils.geometry"
-spec_geom = importlib.util.spec_from_file_location(
-    module_name_geom, ROOT / "layerforge/utils/geometry.py"
-)
-module_geom = importlib.util.module_from_spec(spec_geom)
-sys.modules[module_name_geom] = module_geom
-spec_geom.loader.exec_module(module_geom)  # type: ignore
-
-pkg_utils.calculate_distance = module_geom.calculate_distance
-
-pkg_ref.ReferenceMarkManager = None
-pkg_ref.ReferenceMarkCalculator = None
-pkg_ref.ReferenceMark = None
-pkg_ref.ReferenceMarkAdjuster = None
-pkg_ref.ReferenceMarkConfig = None
-pkg_ref.ReferenceMarkService = None
-
-module_name_config = "layerforge.models.reference_marks.config"
-spec_config = importlib.util.spec_from_file_location(
-    module_name_config, ROOT / "layerforge/models/reference_marks/config.py"
-)
-module_config = importlib.util.module_from_spec(spec_config)
-sys.modules[module_name_config] = module_config
-spec_config.loader.exec_module(module_config)  # type: ignore
-ReferenceMarkConfig = module_config.ReferenceMarkConfig
-pkg_ref.ReferenceMarkConfig = ReferenceMarkConfig
-
-sys.modules[module_name_slice] = module_slice
-
-module_name_manager = "layerforge.models.reference_marks.reference_mark_manager"
-spec_manager = importlib.util.spec_from_file_location(
-    module_name_manager, ROOT / "layerforge/models/reference_marks/reference_mark_manager.py"
-)
-module_manager = importlib.util.module_from_spec(spec_manager)
-sys.modules[module_name_manager] = module_manager
-spec_manager.loader.exec_module(module_manager)  # type: ignore
-ReferenceMarkManager = module_manager.ReferenceMarkManager
-pkg_ref.ReferenceMarkManager = ReferenceMarkManager
-
-module_name_calc = "layerforge.models.reference_marks.reference_mark_calculator"
-spec_calc = importlib.util.spec_from_file_location(
-    module_name_calc, ROOT / "layerforge/models/reference_marks/reference_mark_calculator.py"
-)
-module_calc = importlib.util.module_from_spec(spec_calc)
-sys.modules[module_name_calc] = module_calc
-spec_calc.loader.exec_module(module_calc)  # type: ignore
-ReferenceMarkCalculator = module_calc.ReferenceMarkCalculator
-pkg_ref.ReferenceMarkCalculator = ReferenceMarkCalculator
-
-module_name_service = "layerforge.models.reference_marks.reference_mark_service"
-spec_service = importlib.util.spec_from_file_location(
-    module_name_service, ROOT / "layerforge/models/reference_marks/reference_mark_service.py"
-)
-module_service = importlib.util.module_from_spec(spec_service)
-sys.modules[module_name_service] = module_service
-spec_service.loader.exec_module(module_service)  # type: ignore
-ReferenceMarkService = module_service.ReferenceMarkService
-pkg_ref.ReferenceMarkService = ReferenceMarkService
-
-module_name_mark = "layerforge.models.reference_marks.reference_mark"
-spec_mark = importlib.util.spec_from_file_location(
-    module_name_mark, ROOT / "layerforge/models/reference_marks/reference_mark.py"
-)
-module_mark = importlib.util.module_from_spec(spec_mark)
-sys.modules[module_name_mark] = module_mark
-spec_mark.loader.exec_module(module_mark)  # type: ignore
-ReferenceMark = module_mark.ReferenceMark
-pkg_ref.ReferenceMark = ReferenceMark
-
-module_name_adjuster = "layerforge.models.reference_marks.reference_mark_adjuster"
-spec_adjuster = importlib.util.spec_from_file_location(
-    module_name_adjuster, ROOT / "layerforge/models/reference_marks/reference_mark_adjuster.py"
-)
-module_adjuster = importlib.util.module_from_spec(spec_adjuster)
-sys.modules[module_name_adjuster] = module_adjuster
-spec_adjuster.loader.exec_module(module_adjuster)  # type: ignore
-ReferenceMarkAdjuster = module_adjuster.ReferenceMarkAdjuster
-pkg_ref.ReferenceMarkAdjuster = ReferenceMarkAdjuster
-
-spec_slice.loader.exec_module(module_slice)  # type: ignore
-Slice = module_slice.Slice
+from layerforge.models.reference_marks import ReferenceMarkManager, ReferenceMarkService, ReferenceMarkConfig
+from layerforge.models.slicing import Slice
 
 
 def test_inherit_mark_within_polygon():


### PR DESCRIPTION
## Summary
- clean up reference mark tests to use normal imports

## Testing
- `pytest -k reference_mark_calculator -q` *(fails: could not import 'trimesh')*

------
https://chatgpt.com/codex/tasks/task_e_6849cd447c708333bb0f05497650e9f1